### PR TITLE
レッスン画面API繋ぎ込み # 74

### DIFF
--- a/features/lesson/components/StatusButton.tsx
+++ b/features/lesson/components/StatusButton.tsx
@@ -8,7 +8,11 @@ type Props = {
 
 export const StatusButton: FC<Props> = ({ children, selected = false }) => {
   const background = selected ? '#D9D9D9' : '#00A5D4';
-  return <Button color={background}>{children}</Button>;
+  return (
+    <Button color={background} disabled={selected}>
+      {children}
+    </Button>
+  );
 };
 
 const Button = styled.button`

--- a/features/lesson/components/StatusIcon.tsx
+++ b/features/lesson/components/StatusIcon.tsx
@@ -22,7 +22,7 @@ const IconSvg = styled.svg`
 `;
 
 type Props = {
-  status: 'not_started' | 'in_progress' | 'completed';
+  status: 'before_attendance' | 'in_attendance' | 'completed_attendance';
   size?: 'small' | 'medium';
 };
 export const StatusIcon: FC<Props> = ({ status, size = 'medium' }) => {
@@ -47,11 +47,11 @@ export const StatusIcon: FC<Props> = ({ status, size = 'medium' }) => {
   };
   const iconSize = getIconSize(size);
   switch (status) {
-    case 'not_started':
+    case 'before_attendance':
       return <Icon background="#D9D9D9" size={iconSize.circleSize} />;
-    case 'in_progress':
+    case 'in_attendance':
       return <Icon background="#6D8DFF" size={iconSize.circleSize} />;
-    case 'completed':
+    case 'completed_attendance':
       return (
         <Icon background="#F58909" size={iconSize.circleSize}>
           <IconSvg

--- a/features/lesson/components/TitleStatusCard.tsx
+++ b/features/lesson/components/TitleStatusCard.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { StatusIcon } from './StatusIcon';
 
 type Props = {
-  status: 'not_started' | 'in_progress' | 'completed';
+  status: 'before_attendance' | 'in_attendance' | 'completed_attendance';
   title: string;
 };
 export const TitleStatusCard: FC<Props> = ({ title, status }) => {

--- a/hooks/useFetchChapter.ts
+++ b/hooks/useFetchChapter.ts
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 
 type Data = Chapter & {
   lessons: (Lesson & {
-    lesson_attendance: LessonAttendance;
+    lessonAttendance: LessonAttendance;
   })[];
 };
 

--- a/hooks/useFetchChapter.ts
+++ b/hooks/useFetchChapter.ts
@@ -20,7 +20,6 @@ export const useFetchChapter = ({ attendanceId, chapterId }: Args) => {
 
   useEffect(() => {
     if (attendanceId === undefined || chapterId === undefined) return;
-    console.log(attendanceId, chapterId);
     Axios.get('api/proxy/api/v1/course/chapter/?attendance_id=' + attendanceId + '&chapter_id=' + chapterId).then(
       (res) => {
         setChapter(res.data.data);

--- a/hooks/useFetchChapter.ts
+++ b/hooks/useFetchChapter.ts
@@ -1,0 +1,32 @@
+import { Axios } from '@/lib/api';
+import { Chapter } from '@/types/Chapter';
+import { Lesson } from '@/types/Lesson';
+import { LessonAttendance } from '@/types/LessonAttendance';
+import { useEffect, useState } from 'react';
+
+type Data = Chapter & {
+  lessons: (Lesson & {
+    lesson_attendance: LessonAttendance;
+  })[];
+};
+
+type Args = {
+  attendanceId: string | undefined;
+  chapterId: string | undefined;
+};
+
+export const useFetchChapter = ({ attendanceId, chapterId }: Args) => {
+  const [chapter, setChapter] = useState<Data | null>(null);
+
+  useEffect(() => {
+    if (attendanceId === undefined || chapterId === undefined) return;
+    console.log(attendanceId, chapterId);
+    Axios.get('api/proxy/api/v1/course/chapter/?attendance_id=' + attendanceId + '&chapter_id=' + chapterId).then(
+      (res) => {
+        setChapter(res.data.data);
+      }
+    );
+  }, [attendanceId, chapterId]);
+
+  return [chapter as Data] as const;
+};

--- a/hooks/useFetchCourse.ts
+++ b/hooks/useFetchCourse.ts
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react';
 type Data = Course & {
   chapters: (Chapter & {
     lessons: (Lesson & {
-      lesson_attendance: LessonAttendance;
+      lessonAttendance: LessonAttendance;
     })[];
   })[];
 };

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -9,11 +9,24 @@ import { StatusIcon } from '@/features/lesson/components/StatusIcon';
 import { StatusButton } from '@/features/lesson/components/StatusButton';
 import { Movie } from '@/components/elements/Movie';
 import { useWindowSize } from '@/hooks/useWindowSize';
+import { useFetchChapter } from '@/hooks/useFetchChapter';
+import { useRouter } from 'next/router';
+
+type Query = {
+  attendanceId?: string;
+  chapterId?: string;
+};
 
 const Chapter: NextPage = () => {
   const [isShowedSideBar, setIsShowedSideBar] = useState(true);
 
   const [width] = useWindowSize();
+  const router = useRouter();
+  const query: Query = router.query;
+  const [chapter] = useFetchChapter({
+    attendanceId: query.attendanceId,
+    chapterId: query.chapterId,
+  });
 
   // パン屑のリンクリスト
   const links = [

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -111,7 +111,7 @@ const Chapter: NextPage = () => {
               <SideBar>
                 <ul className="mt-[30px]">
                   <li className="mb-[20px]">
-                    <div className="">
+                    <div>
                       <p className="text-[18px] font-semibold mb-3">チャプター進捗 {calculateChapterProgeress()}%</p>
                       <ProgressBar progress={calculateChapterProgeress()} />
                     </div>
@@ -143,7 +143,7 @@ const Chapter: NextPage = () => {
               </div>
               <ul className="md:hidden mt-[30px] border-black border-b">
                 <li className="mb-[20px]">
-                  <div className="">
+                  <div>
                     <p className="text-[18px] font-semibold mb-3">チャプター進捗 {calculateChapterProgeress()}%</p>
                     <ProgressBar progress={calculateChapterProgeress()} />
                   </div>
@@ -151,7 +151,10 @@ const Chapter: NextPage = () => {
                 {chapter.lessons.map((lesson) => {
                   return (
                     <li key={lesson.lesson_id}>
-                      <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
+                      <div
+                        className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between"
+                        onClick={() => clickHandler(lesson.lesson_id)}
+                      >
                         <p className="text-[18px] text-[#6D8DFF] font-semibold">{lesson.title}</p>
                         <StatusIcon status={lesson.lessonAttendance.status} size="small" />
                       </div>

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -164,9 +164,9 @@ const Chapter: NextPage = () => {
                 <h2 className="font-semibold text-[25px] md:text-[30px]">{currentLesson?.title}</h2>
               </div>
               <div className="my-5 overflow-auto">
-                {(width as number) > 0 && (
+                {(width as number) > 0 && currentLesson && (
                   <Movie
-                    videoId={'rneIc3LX1vs'}
+                    videoId={currentLesson.url}
                     height={(width as number) > 640 ? 405 : 180}
                     width={(width as number) > 640 ? 720 : 320}
                   />
@@ -186,8 +186,7 @@ const Chapter: NextPage = () => {
                 </StatusButton>
               </div>
               <div className="mt-5">
-                <p>Index</p>
-                <p>{currentLesson?.remarks}</p>
+                <p className="whitespace-pre-wrap">{currentLesson?.remarks}</p>
               </div>
             </div>
           </>

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -56,7 +56,6 @@ const Chapter: NextPage = () => {
 
     // 進捗完了レッスン数
     const completedLessonTotalCount = chapter.lessons.filter((lesson) => {
-      console.log(lesson);
       return lesson.lessonAttendance?.status === STATUS_COMPLETED_ATTENDANCE;
     }).length;
 

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -3,7 +3,7 @@ import { ToggleButton } from '@/components/elements/ToggleButton';
 import { ProgressBar } from '@/components/elements/ProgressBar';
 import { SideBar } from '@/components/elements/SideBar';
 import { NextPage } from 'next';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Breadcrumb } from '@/components/elements/Breadcrumb';
 import { StatusIcon } from '@/features/lesson/components/StatusIcon';
 import { StatusButton } from '@/features/lesson/components/StatusButton';
@@ -11,6 +11,7 @@ import { Movie } from '@/components/elements/Movie';
 import { useWindowSize } from '@/hooks/useWindowSize';
 import { useFetchChapter } from '@/hooks/useFetchChapter';
 import { useRouter } from 'next/router';
+import { Loading } from '@/components/utils/Loading';
 
 type Query = {
   attendanceId?: string;
@@ -27,6 +28,15 @@ const Chapter: NextPage = () => {
     attendanceId: query.attendanceId,
     chapterId: query.chapterId,
   });
+
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (chapter !== null) {
+      setIsLoading(false);
+      return;
+    }
+  }, [chapter]);
 
   // パン屑のリンクリスト
   const links = [
@@ -48,130 +58,138 @@ const Chapter: NextPage = () => {
     <>
       <Header />
       <div className="flex">
-        {isShowedSideBar ? (
-          <SideBar>
-            <ul className="mt-[30px]">
-              <li className="mb-[20px]">
-                <div className="">
-                  <p className="text-[18px] font-semibold mb-3">チャプター進捗 33%</p>
-                  <ProgressBar progress={33} />
-                </div>
-              </li>
-              <li>
-                <a href="#">
-                  <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
-                    <p className="text-[18px] text-[#6D8DFF] font-semibold">Lesson 1</p>
-                    <StatusIcon status="in_progress" size="small" />
-                  </div>
-                </a>
-              </li>
-              <li>
-                <a href="#">
-                  <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
-                    <p className="text-[18px] text-[#B5B5B5] font-semibold">Lesson 2</p>
-                    <StatusIcon status="not_started" size="small" />
-                  </div>
-                </a>
-              </li>
-              <li>
-                <a href="#">
-                  <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
-                    <p className="text-[18px] text-[#B5B5B5] font-semibold">Lesson 3</p>
-                    <StatusIcon status="not_started" size="small" />
-                  </div>
-                </a>
-              </li>
-              <li>
-                <a href="#">
-                  <div className="border-[#F58909] border-t-2 min-h-[65px] flex items-center justify-between">
-                    <p className="text-[18px] text-[#F58909] font-semibold">Lesson 4</p>
-                    <StatusIcon status="completed" size="small" />
-                  </div>
-                </a>
-              </li>
-            </ul>
-            <ToggleButton isShowedSideBar={isShowedSideBar} setIsShowedSideBar={setIsShowedSideBar} />
-          </SideBar>
+        {isLoading ? (
+          <div className="w-3/4 mx-auto min-h-[100vh] mt-10 mb-10">
+            <Loading />
+          </div>
         ) : (
-          <ToggleButton isShowedSideBar={isShowedSideBar} setIsShowedSideBar={setIsShowedSideBar} />
-        )}
-
-        <div className="w-3/4 mx-auto min-h-[100vh] mb-10">
-          <Breadcrumb links={links} />
-          <div className="mt-[20px] border-black border-b pb-5">
-            <h2 className="font-semibold text-[30px] md:text-[36px]">チャプタータイトル</h2>
-          </div>
-          <ul className="md:hidden mt-[30px] border-black border-b">
-            <li className="mb-[20px]">
-              <div className="">
-                <p className="text-[18px] font-semibold mb-3">チャプター進捗 33%</p>
-                <ProgressBar progress={33} />
-              </div>
-            </li>
-            <li>
-              <a href="#">
-                <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
-                  <p className="text-[18px] text-[#6D8DFF] font-semibold">Lesson 1</p>
-                  <StatusIcon status="in_progress" size="small" />
-                </div>
-              </a>
-            </li>
-            <li>
-              <a href="#">
-                <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
-                  <p className="text-[18px] text-[#B5B5B5] font-semibold">Lesson 2</p>
-                  <StatusIcon status="not_started" size="small" />
-                </div>
-              </a>
-            </li>
-            <li>
-              <a href="#">
-                <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
-                  <p className="text-[18px] text-[#B5B5B5] font-semibold">Lesson 3</p>
-                  <StatusIcon status="not_started" size="small" />
-                </div>
-              </a>
-            </li>
-            <li>
-              <a href="#">
-                <div className="border-[#F58909] border-t-2 min-h-[65px] flex items-center justify-between">
-                  <p className="text-[18px] text-[#F58909] font-semibold">Lesson 4</p>
-                  <StatusIcon status="completed" size="small" />
-                </div>
-              </a>
-            </li>
-          </ul>
-          <div className="mt-5 mx-auto">
-            <h2 className="font-semibold text-[25px] md:text-[30px]">レッスンタイトル</h2>
-          </div>
-          <div className="my-5 overflow-auto">
-            {(width as number) > 0 && (
-              <Movie
-                videoId={'rneIc3LX1vs'}
-                height={(width as number) > 640 ? 405 : 180}
-                width={(width as number) > 640 ? 720 : 320}
-              />
+          <>
+            {isShowedSideBar ? (
+              <SideBar>
+                <ul className="mt-[30px]">
+                  <li className="mb-[20px]">
+                    <div className="">
+                      <p className="text-[18px] font-semibold mb-3">チャプター進捗 33%</p>
+                      <ProgressBar progress={33} />
+                    </div>
+                  </li>
+                  <li>
+                    <a href="#">
+                      <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
+                        <p className="text-[18px] text-[#6D8DFF] font-semibold">Lesson 1</p>
+                        <StatusIcon status="in_progress" size="small" />
+                      </div>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#">
+                      <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
+                        <p className="text-[18px] text-[#B5B5B5] font-semibold">Lesson 2</p>
+                        <StatusIcon status="not_started" size="small" />
+                      </div>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#">
+                      <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
+                        <p className="text-[18px] text-[#B5B5B5] font-semibold">Lesson 3</p>
+                        <StatusIcon status="not_started" size="small" />
+                      </div>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#">
+                      <div className="border-[#F58909] border-t-2 min-h-[65px] flex items-center justify-between">
+                        <p className="text-[18px] text-[#F58909] font-semibold">Lesson 4</p>
+                        <StatusIcon status="completed" size="small" />
+                      </div>
+                    </a>
+                  </li>
+                </ul>
+                <ToggleButton isShowedSideBar={isShowedSideBar} setIsShowedSideBar={setIsShowedSideBar} />
+              </SideBar>
+            ) : (
+              <ToggleButton isShowedSideBar={isShowedSideBar} setIsShowedSideBar={setIsShowedSideBar} />
             )}
-          </div>
-          <div className="flex justify-start">
-            <StatusButton selected={true}>Lesson未実施</StatusButton>
-            <span className="ml-10" />
-            <StatusButton selected={false}>Lesson開始</StatusButton>
-            <span className="ml-10" />
-            <StatusButton selected={false}>Lesson完了</StatusButton>
-          </div>
-          <div className="mt-5">
-            <p>Index</p>
-            <p>
-              ・本レッスンの概要 0:30~ <br />
-              ・プログラミングとは 1:00~
-              <br />
-              ・PHPとはどんな言語 4:00~ <br />
-              ・PHPで計算してみよう 7:00~ <br />
-              ・まとめ 9:00~
-            </p>
-          </div>
-        </div>
+
+            <div className="w-3/4 mx-auto min-h-[100vh] mb-10">
+              <Breadcrumb links={links} />
+              <div className="mt-[20px] border-black border-b pb-5">
+                <h2 className="font-semibold text-[30px] md:text-[36px]">チャプタータイトル</h2>
+              </div>
+              <ul className="md:hidden mt-[30px] border-black border-b">
+                <li className="mb-[20px]">
+                  <div className="">
+                    <p className="text-[18px] font-semibold mb-3">チャプター進捗 33%</p>
+                    <ProgressBar progress={33} />
+                  </div>
+                </li>
+                <li>
+                  <a href="#">
+                    <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
+                      <p className="text-[18px] text-[#6D8DFF] font-semibold">Lesson 1</p>
+                      <StatusIcon status="in_progress" size="small" />
+                    </div>
+                  </a>
+                </li>
+                <li>
+                  <a href="#">
+                    <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
+                      <p className="text-[18px] text-[#B5B5B5] font-semibold">Lesson 2</p>
+                      <StatusIcon status="not_started" size="small" />
+                    </div>
+                  </a>
+                </li>
+                <li>
+                  <a href="#">
+                    <div className="border-[#B5B5B5] border-t-2 min-h-[65px] flex items-center justify-between">
+                      <p className="text-[18px] text-[#B5B5B5] font-semibold">Lesson 3</p>
+                      <StatusIcon status="not_started" size="small" />
+                    </div>
+                  </a>
+                </li>
+                <li>
+                  <a href="#">
+                    <div className="border-[#F58909] border-t-2 min-h-[65px] flex items-center justify-between">
+                      <p className="text-[18px] text-[#F58909] font-semibold">Lesson 4</p>
+                      <StatusIcon status="completed" size="small" />
+                    </div>
+                  </a>
+                </li>
+              </ul>
+              <div className="mt-5 mx-auto">
+                <h2 className="font-semibold text-[25px] md:text-[30px]">レッスンタイトル</h2>
+              </div>
+              <div className="my-5 overflow-auto">
+                {(width as number) > 0 && (
+                  <Movie
+                    videoId={'rneIc3LX1vs'}
+                    height={(width as number) > 640 ? 405 : 180}
+                    width={(width as number) > 640 ? 720 : 320}
+                  />
+                )}
+              </div>
+              <div className="flex justify-start">
+                <StatusButton selected={true}>Lesson未実施</StatusButton>
+                <span className="ml-10" />
+                <StatusButton selected={false}>Lesson開始</StatusButton>
+                <span className="ml-10" />
+                <StatusButton selected={false}>Lesson完了</StatusButton>
+              </div>
+              <div className="mt-5">
+                <p>Index</p>
+                <p>
+                  ・本レッスンの概要 0:30~ <br />
+                  ・プログラミングとは 1:00~
+                  <br />
+                  ・PHPとはどんな言語 4:00~ <br />
+                  ・PHPで計算してみよう 7:00~ <br />
+                  ・まとめ 9:00~
+                </p>
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </>
   );

--- a/pages/course.tsx
+++ b/pages/course.tsx
@@ -139,7 +139,6 @@ const Course: NextPage = () => {
             </div>
           </>
         )}
-        ;
       </div>
     </>
   );

--- a/pages/course.tsx
+++ b/pages/course.tsx
@@ -119,7 +119,9 @@ const Course: NextPage = () => {
                       {chapter.lessons.map((lesson) => {
                         return (
                           <div className="my-5" key={lesson.lesson_id}>
-                            <Link href="/chapter">
+                            <Link
+                              href={{ pathname: '/chapter', query: { attendanceId, chapterId: chapter.chapter_id } }}
+                            >
                               <a>
                                 <TitleStatusCard
                                   status={statusString(lesson.lesson_attendance.status)}

--- a/pages/course.tsx
+++ b/pages/course.tsx
@@ -41,20 +41,6 @@ const Course: NextPage = () => {
         ]
       : [];
 
-  // TODO 後ほど文字列に変更される
-  const statusString = (status: number) => {
-    switch (status) {
-      case 1:
-        return 'not_started';
-      case 2:
-        return 'in_progress';
-      case 3:
-        return 'completed';
-      default:
-        return 'not_started';
-    }
-  };
-
   return (
     <>
       <Header />
@@ -123,10 +109,7 @@ const Course: NextPage = () => {
                               href={{ pathname: '/chapter', query: { attendanceId, chapterId: chapter.chapter_id } }}
                             >
                               <a>
-                                <TitleStatusCard
-                                  status={statusString(lesson.lesson_attendance.status)}
-                                  title={lesson.title}
-                                />
+                                <TitleStatusCard status={lesson.lessonAttendance.status} title={lesson.title} />
                               </a>
                             </Link>
                           </div>

--- a/types/LessonAttendance.ts
+++ b/types/LessonAttendance.ts
@@ -1,4 +1,4 @@
 export type LessonAttendance = {
   lesson_attendance_id: number;
-  status: number;
+  status: 'before_attendance' | 'in_attendance' | 'completed_attendance';
 };


### PR DESCRIPTION
##  Issue
https://gut-familie.atlassian.net/browse/JKA-74

## やったこと
- レッスン画面のデータをAPIから取得したデータから参照するように修正。

## 確認方法
- Laravelのブランチを`feature/kou/jka-78`に移動。
- `php artisan migrate:fresh --seed`を実行
- http://localhost:3000/chapter?attendanceId=1&chapterId=2 にアクセス

## 懸念点
- レッスン画面のパン屑リストの講座名を表示するにはAPIのスキーマから変更が必要。