### PR TITLE
講座登録画面において、バリデーションまで実装 #145

### DIFF
--- a/features/course/components/CourseCard.tsx
+++ b/features/course/components/CourseCard.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import { FC } from 'react';
-import { Course } from '@/types/Course';
+import { Course } from '@/features/course/types/Course';
 
 type Props = {
   course: Course;

--- a/features/course/components/CourseCardList.tsx
+++ b/features/course/components/CourseCardList.tsx
@@ -1,4 +1,4 @@
-import { Course } from '@/types/Course';
+import { Course } from '@/features/course/types/Course';
 import React, { FC } from 'react';
 import CourseCard from './CourseCard';
 import Link from 'next/link';

--- a/features/course/schemas/StoreSchema.ts
+++ b/features/course/schemas/StoreSchema.ts
@@ -1,0 +1,13 @@
+import * as yup from 'yup';
+import { StoreCourse } from '../types/StoreCourse';
+
+export const StoreSchema: yup.Schema<StoreCourse> = yup.object().shape({
+  title: yup.string().required('講座名を入力してください。'),
+  image: yup
+    .mixed<File>()
+    .required()
+    .test('file', '画像ファイルを選択してください。', (value) => {
+      if (value instanceof File === false) return false;
+      return true;
+    }),
+});

--- a/features/course/types/Course.ts
+++ b/features/course/types/Course.ts
@@ -1,5 +1,6 @@
-import { Attendance } from './Attendance';
-import { Instructor } from './Instructor';
+import { Attendance } from '@/types/Attendance';
+import { Instructor } from '@/types/Instructor';
+
 export type Course = {
   course_id: number;
   title: string;

--- a/features/course/types/StoreCourse.ts
+++ b/features/course/types/StoreCourse.ts
@@ -1,0 +1,5 @@
+import { Course } from './Course';
+
+export type StoreCourse = Pick<Course, 'title'> & {
+  image: File;
+};

--- a/hooks/useFetchCourse.ts
+++ b/hooks/useFetchCourse.ts
@@ -1,6 +1,6 @@
 import { Axios } from '@/lib/api';
 import { Chapter } from '@/types/Chapter';
-import { Course } from '@/types/Course';
+import { Course } from '@/features/course/types/Course';
 import { Lesson } from '@/types/Lesson';
 import { LessonAttendance } from '@/types/LessonAttendance';
 import { useEffect, useState } from 'react';

--- a/hooks/useFetchCourses.ts
+++ b/hooks/useFetchCourses.ts
@@ -1,6 +1,6 @@
 import { Axios } from '@/lib/api';
 import { useEffect, useState } from 'react';
-import { Course } from '@/types/Course';
+import { Course } from '@/features/course/types/Course';
 
 export const useFetchCourses = (args: {
   setIsLoading: (value: React.SetStateAction<boolean>) => void;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "styled-components": "^5.3.6"
   },
   "devDependencies": {
+    "@hookform/resolvers": "^2.9.11",
     "@types/node": "18.7.21",
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",
@@ -31,8 +32,10 @@
     "next-http-proxy-middleware": "^1.2.5",
     "postcss": "^8.4.18",
     "prettier": "^2.7.1",
+    "react-hook-form": "^7.43.2",
     "react-dropzone": "^14.2.3",
     "tailwindcss": "^3.2.1",
-    "typescript": "4.8.3"
+    "typescript": "4.8.3",
+    "yup": "^1.0.0"
   }
 }

--- a/pages/course/register.tsx
+++ b/pages/course/register.tsx
@@ -1,24 +1,53 @@
 import Header from '@/components/layouts/Header';
 import { NextPage } from 'next';
 import { useDropzone } from 'react-dropzone';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { StoreSchema } from '@/features/course/schemas/StoreSchema';
+import { StoreCourse } from '@/features/course/types/StoreCourse';
 
 const Register: NextPage = () => {
-  const { getRootProps, getInputProps } = useDropzone({
-    onDrop: (acceptedFiles) => {
-      console.log(acceptedFiles);
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<StoreCourse>({
+    mode: 'onSubmit',
+    resolver: yupResolver(StoreSchema),
+    defaultValues: {
+      title: '',
     },
   });
+
+  const { getRootProps, getInputProps } = useDropzone({
+    onDrop: (acceptedFiles: File[]) => {
+      if (acceptedFiles[0] instanceof File) {
+        setValue('image', acceptedFiles[0]);
+      }
+    },
+  });
+
+  const submitHandler = (data: StoreCourse) => {
+    console.log(data);
+  };
+
   return (
     <>
       <Header />
       <div className="md:border md:w-3/6 min-h-[80vh] mt-10 mb-10 bg-white mx-auto">
-        <form>
+        <form onSubmit={handleSubmit(submitHandler)}>
           <h2 className="text-center my-10 text-3xl">講座登録</h2>
           <div className="w-4/5 mx-auto">
             <div className="my-5">
               <label htmlFor="title">
                 <p>講座名</p>
-                <input className="rounded border-b-2 w-full focus:outline-none focus:border-[#B0ABAB]" name="title" />
+                <input
+                  id="title"
+                  className="rounded border-b-2 w-full focus:outline-none focus:border-[#B0ABAB]"
+                  {...register('title')}
+                />
+                {errors.title && <p className="text-red-500">{errors.title.message}</p>}
               </label>
             </div>
             <div className="my-5">
@@ -29,7 +58,7 @@ const Register: NextPage = () => {
                     className: 'border-2 border-dotted h-80 flex justify-center items-center',
                   })}
                 >
-                  <input {...getInputProps()} />
+                  <input {...getInputProps()} {...register('image')} />
                   <div className="flex flex-col justify-center items-center ">
                     <svg
                       aria-hidden="true"
@@ -49,10 +78,14 @@ const Register: NextPage = () => {
                     <p>画像アップロード</p>
                   </div>
                 </div>
+                {errors.image && <p className="text-red-500">{errors.image.message}</p>}
               </label>
             </div>
-            <div className="my-5">
-              <button className="block rounded bg-[#00A5D4] w-4/5 mx-auto text-center text-white font-semibold text-2xl py-2 hover:opacity-75">
+            <div className="my-5 text-center">
+              <button
+                type="submit"
+                className="rounded bg-[#00A5D4] w-4/5 text-white font-semibold text-2xl py-2 hover:opacity-75"
+              >
                 登録
               </button>
             </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,6 +169,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@hookform/resolvers@^2.9.11":
+  version "2.9.11"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.9.11.tgz#9ce96e7746625a89239f68ca57c4f654264c17ef"
+  integrity sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ==
+
 "@humanwhocodes/config-array@^0.10.5":
   version "0.10.5"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz"
@@ -2028,6 +2033,11 @@ prop-types@15.8.1, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
@@ -2064,6 +2074,11 @@ react-dropzone@^14.2.3:
     attr-accept "^2.2.2"
     file-selector "^0.6.0"
     prop-types "^15.8.1"
+
+react-hook-form@^7.43.2:
+  version "7.43.9"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.43.9.tgz#84b56ac2f38f8e946c6032ccb760e13a1037c66d"
+  integrity sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -2358,6 +2373,11 @@ text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
@@ -2369,6 +2389,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"
@@ -2408,6 +2433,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 typescript@4.8.3:
   version "4.8.3"
@@ -2505,3 +2535,13 @@ youtube-player@5.5.2:
     debug "^2.6.6"
     load-script "^1.0.0"
     sister "^3.0.0"
+
+yup@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.1.1.tgz#49dbcf5ae7693ed0a36ed08a9e9de0a09ac18e6b"
+  integrity sha512-KfCGHdAErqFZWA5tZf7upSUnGKuTOnsI3hUsLr7fgVtx+DK04NPV01A68/FslI4t3s/ZWpvXJmgXhd7q6ICnag==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-145

## やったこと
React Hook Form + yupによるフォームとバリデーションの実装

## 確認方法
- コンテナ内で、`yarn`を実行
- http://localhost:3000/course/register にアクセス
- 講座名、画像をアップロードしないで登録ボタンをクリック