### PR TITLE
mod:選択中のレッスンを保持

### DIFF
--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -81,20 +81,19 @@ const Chapter: NextPage = () => {
     if (chapter !== undefined) {
       setIsLoading(false);
       if (currentLesson !== null) {
-        const newLesson = chapter.lessons.find((lesson) => lesson.lesson_id === currentLesson.lesson_id) as Lesson & {
-          lessonAttendance: LessonAttendance;
-        };
-        setCurrentLesson(newLesson);
+        const newLesson = chapter.lessons.find((lesson) => lesson.lesson_id === currentLesson.lesson_id);
+        if (newLesson) {
+          setCurrentLesson(newLesson);
+        }
       } else {
-        setCurrentLesson(
-          chapter.lessons[0] as Lesson & {
-            lessonAttendance: LessonAttendance;
-          }
-        );
+        const initialLesson = chapter.lessons[0];
+        if (initialLesson) {
+          setCurrentLesson(initialLesson);
+        }
       }
       return;
     }
-  }, [chapter]);
+  }, [chapter, currentLesson]);
 
   // パン屑のリンクリスト
   const links = [

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -91,7 +91,6 @@ const Chapter: NextPage = () => {
           setCurrentLesson(initialLesson);
         }
       }
-      return;
     }
   }, [chapter, currentLesson]);
 

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -59,6 +59,8 @@ const Chapter: NextPage = () => {
     | null
   >(null);
 
+  const [selectingLesson, setSelectingLesson] = useState(0);
+
   const calculateChapterProgeress = (): number => {
     // チャプター取得前は0を返す
     if (chapter === undefined) return 0;
@@ -78,10 +80,10 @@ const Chapter: NextPage = () => {
   };
 
   useEffect(() => {
-    if (chapter !== undefined) {
+    if (chapter !== undefined && selectingLesson !== undefined) {
       setIsLoading(false);
       setCurrentLesson(
-        chapter.lessons[0] as Lesson & {
+        chapter.lessons[selectingLesson] as Lesson & {
           lessonAttendance: LessonAttendance;
         }
       );
@@ -105,10 +107,11 @@ const Chapter: NextPage = () => {
     },
   ];
 
-  const clickHandler = (lessonId: number) => () => {
+  const clickHandler = (lessonId: number, index: number) => () => {
     const newLesson = chapter?.lessons.find((lesson) => lesson.lesson_id === lessonId) as Lesson & {
       lessonAttendance: LessonAttendance;
     };
+    setSelectingLesson(index);
     setCurrentLesson(newLesson);
   };
 
@@ -131,11 +134,11 @@ const Chapter: NextPage = () => {
                       <ProgressBar progress={calculateChapterProgeress()} />
                     </div>
                   </li>
-                  {chapter?.lessons.map((lesson) => {
+                  {chapter?.lessons.map((lesson, index) => {
                     return (
                       <StyleSideBarList
                         key={lesson.lesson_id}
-                        onClick={clickHandler(lesson.lesson_id)}
+                        onClick={clickHandler(lesson.lesson_id, index)}
                         isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                       >
                         <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>
@@ -162,11 +165,11 @@ const Chapter: NextPage = () => {
                     <ProgressBar progress={calculateChapterProgeress()} />
                   </div>
                 </li>
-                {chapter?.lessons.map((lesson) => {
+                {chapter?.lessons.map((lesson, index) => {
                   return (
                     <StyleSideBarList
                       key={lesson.lesson_id}
-                      onClick={clickHandler(lesson.lesson_id)}
+                      onClick={clickHandler(lesson.lesson_id, index)}
                       isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                     >
                       <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -59,8 +59,6 @@ const Chapter: NextPage = () => {
     | null
   >(null);
 
-  const [selectingLesson, setSelectingLesson] = useState(0);
-
   const calculateChapterProgeress = (): number => {
     // チャプター取得前は0を返す
     if (chapter === undefined) return 0;
@@ -80,13 +78,20 @@ const Chapter: NextPage = () => {
   };
 
   useEffect(() => {
-    if (chapter !== undefined && selectingLesson !== undefined) {
+    if (chapter !== undefined) {
       setIsLoading(false);
-      setCurrentLesson(
-        chapter.lessons[selectingLesson] as Lesson & {
+      if (currentLesson !== null) {
+        const newLesson = chapter.lessons.find((lesson) => lesson.lesson_id === currentLesson.lesson_id) as Lesson & {
           lessonAttendance: LessonAttendance;
-        }
-      );
+        };
+        setCurrentLesson(newLesson);
+      } else {
+        setCurrentLesson(
+          chapter.lessons[0] as Lesson & {
+            lessonAttendance: LessonAttendance;
+          }
+        );
+      }
       return;
     }
   }, [chapter]);
@@ -107,11 +112,10 @@ const Chapter: NextPage = () => {
     },
   ];
 
-  const clickHandler = (lessonId: number, index: number) => () => {
+  const clickHandler = (lessonId: number) => () => {
     const newLesson = chapter?.lessons.find((lesson) => lesson.lesson_id === lessonId) as Lesson & {
       lessonAttendance: LessonAttendance;
     };
-    setSelectingLesson(index);
     setCurrentLesson(newLesson);
   };
 
@@ -134,11 +138,11 @@ const Chapter: NextPage = () => {
                       <ProgressBar progress={calculateChapterProgeress()} />
                     </div>
                   </li>
-                  {chapter?.lessons.map((lesson, index) => {
+                  {chapter?.lessons.map((lesson) => {
                     return (
                       <StyleSideBarList
                         key={lesson.lesson_id}
-                        onClick={clickHandler(lesson.lesson_id, index)}
+                        onClick={clickHandler(lesson.lesson_id)}
                         isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                       >
                         <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>
@@ -165,11 +169,11 @@ const Chapter: NextPage = () => {
                     <ProgressBar progress={calculateChapterProgeress()} />
                   </div>
                 </li>
-                {chapter?.lessons.map((lesson, index) => {
+                {chapter?.lessons.map((lesson) => {
                   return (
                     <StyleSideBarList
                       key={lesson.lesson_id}
-                      onClick={clickHandler(lesson.lesson_id, index)}
+                      onClick={clickHandler(lesson.lesson_id)}
                       isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                     >
                       <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-273

## やったこと
＜機能実装＞
- レッスン状態を更新しても選択中のレッスンを保持できるようにする


## 確認方法
- `npm install`または、'yarn'
- http://localhost:3000/chapter?attendanceId=1&chapterId=1 にアクセス
　以下の3つのいずれかのボタンを押下し、状態を更新する 
　・Lesson未実施
　・Lesson開始
　・Lesson完了
- 押下したボタンのカラーがrgb(203 213 225)になっていること
