### PR TITLE
React開発：レッスン一覧画面（受講生側）押下後の遷移先修正

### DIFF
--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -81,20 +81,19 @@ const Chapter: NextPage = () => {
     if (chapter !== undefined) {
       setIsLoading(false);
       if (currentLesson !== null) {
-        const newLesson = chapter.lessons.find((lesson) => lesson.lesson_id === currentLesson.lesson_id) as Lesson & {
-          lessonAttendance: LessonAttendance;
-        };
-        setCurrentLesson(newLesson);
+        const newLesson = chapter.lessons.find((lesson) => lesson.lesson_id === currentLesson.lesson_id);
+        if (newLesson) {
+          setCurrentLesson(newLesson);
+        }
       } else {
-        setCurrentLesson(
-          chapter.lessons[0] as Lesson & {
-            lessonAttendance: LessonAttendance;
-          }
-        );
+        const initialLesson = chapter.lessons[0];
+        if (initialLesson) {
+          setCurrentLesson(initialLesson);
+        }
       }
       return;
     }
-  }, [chapter]);
+  }, [chapter, currentLesson]);
 
   // パン屑のリンクリスト
   const links = [

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -91,7 +91,6 @@ const Chapter: NextPage = () => {
           setCurrentLesson(initialLesson);
         }
       }
-      return;
     }
   }, [chapter, currentLesson]);
 

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -59,6 +59,8 @@ const Chapter: NextPage = () => {
     | null
   >(null);
 
+  const [selectingLesson, setSelectingLesson] = useState(0);
+
   const calculateChapterProgeress = (): number => {
     // チャプター取得前は0を返す
     if (chapter === undefined) return 0;
@@ -78,10 +80,10 @@ const Chapter: NextPage = () => {
   };
 
   useEffect(() => {
-    if (chapter !== undefined) {
+    if (chapter !== undefined && selectingLesson !== undefined) {
       setIsLoading(false);
       setCurrentLesson(
-        chapter.lessons[0] as Lesson & {
+        chapter.lessons[selectingLesson] as Lesson & {
           lessonAttendance: LessonAttendance;
         }
       );
@@ -105,10 +107,11 @@ const Chapter: NextPage = () => {
     },
   ];
 
-  const clickHandler = (lessonId: number) => () => {
+  const clickHandler = (lessonId: number, index: number) => () => {
     const newLesson = chapter?.lessons.find((lesson) => lesson.lesson_id === lessonId) as Lesson & {
       lessonAttendance: LessonAttendance;
     };
+    setSelectingLesson(index);
     setCurrentLesson(newLesson);
   };
 
@@ -131,11 +134,11 @@ const Chapter: NextPage = () => {
                       <ProgressBar progress={calculateChapterProgeress()} />
                     </div>
                   </li>
-                  {chapter?.lessons.map((lesson) => {
+                  {chapter?.lessons.map((lesson, index) => {
                     return (
                       <StyleSideBarList
                         key={lesson.lesson_id}
-                        onClick={clickHandler(lesson.lesson_id)}
+                        onClick={clickHandler(lesson.lesson_id, index)}
                         isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                       >
                         <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>
@@ -162,11 +165,11 @@ const Chapter: NextPage = () => {
                     <ProgressBar progress={calculateChapterProgeress()} />
                   </div>
                 </li>
-                {chapter?.lessons.map((lesson) => {
+                {chapter?.lessons.map((lesson, index) => {
                   return (
                     <StyleSideBarList
                       key={lesson.lesson_id}
-                      onClick={clickHandler(lesson.lesson_id)}
+                      onClick={clickHandler(lesson.lesson_id, index)}
                       isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                     >
                       <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 type Query = {
   attendanceId?: string;
   chapterId?: string;
-  selectId?: number;
+  lessonIndex?: number;
 };
 
 const STATUS_BEFORE_ATTENDANCE = 'before_attendance';
@@ -60,6 +60,8 @@ const Chapter: NextPage = () => {
     | null
   >(null);
 
+  const lessonIndex = query.lessonIndex ? query.lessonIndex : 0;
+
   const calculateChapterProgeress = (): number => {
     // チャプター取得前は0を返す
     if (chapter === undefined) return 0;
@@ -87,13 +89,13 @@ const Chapter: NextPage = () => {
           setCurrentLesson(newLesson);
         }
       } else {
-        const initialLesson = chapter.lessons[query.selectId ? query.selectId : 0];
+        const initialLesson = chapter.lessons[lessonIndex];
         if (initialLesson) {
           setCurrentLesson(initialLesson);
         }
       }
     }
-  }, [chapter, currentLesson]);
+  }, [chapter, currentLesson, lessonIndex]);
 
   // パン屑のリンクリスト
   const links = [

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -19,6 +19,7 @@ import styled from 'styled-components';
 type Query = {
   attendanceId?: string;
   chapterId?: string;
+  selectId?: number;
 };
 
 const STATUS_BEFORE_ATTENDANCE = 'before_attendance';
@@ -86,7 +87,7 @@ const Chapter: NextPage = () => {
           setCurrentLesson(newLesson);
         }
       } else {
-        const initialLesson = chapter.lessons[0];
+        const initialLesson = chapter.lessons[query.selectId ? query.selectId : 0];
         if (initialLesson) {
           setCurrentLesson(initialLesson);
         }

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -59,8 +59,6 @@ const Chapter: NextPage = () => {
     | null
   >(null);
 
-  const [selectingLesson, setSelectingLesson] = useState(0);
-
   const calculateChapterProgeress = (): number => {
     // チャプター取得前は0を返す
     if (chapter === undefined) return 0;
@@ -80,13 +78,20 @@ const Chapter: NextPage = () => {
   };
 
   useEffect(() => {
-    if (chapter !== undefined && selectingLesson !== undefined) {
+    if (chapter !== undefined) {
       setIsLoading(false);
-      setCurrentLesson(
-        chapter.lessons[selectingLesson] as Lesson & {
+      if (currentLesson !== null) {
+        const newLesson = chapter.lessons.find((lesson) => lesson.lesson_id === currentLesson.lesson_id) as Lesson & {
           lessonAttendance: LessonAttendance;
-        }
-      );
+        };
+        setCurrentLesson(newLesson);
+      } else {
+        setCurrentLesson(
+          chapter.lessons[0] as Lesson & {
+            lessonAttendance: LessonAttendance;
+          }
+        );
+      }
       return;
     }
   }, [chapter]);
@@ -107,11 +112,10 @@ const Chapter: NextPage = () => {
     },
   ];
 
-  const clickHandler = (lessonId: number, index: number) => () => {
+  const clickHandler = (lessonId: number) => () => {
     const newLesson = chapter?.lessons.find((lesson) => lesson.lesson_id === lessonId) as Lesson & {
       lessonAttendance: LessonAttendance;
     };
-    setSelectingLesson(index);
     setCurrentLesson(newLesson);
   };
 
@@ -134,11 +138,11 @@ const Chapter: NextPage = () => {
                       <ProgressBar progress={calculateChapterProgeress()} />
                     </div>
                   </li>
-                  {chapter?.lessons.map((lesson, index) => {
+                  {chapter?.lessons.map((lesson) => {
                     return (
                       <StyleSideBarList
                         key={lesson.lesson_id}
-                        onClick={clickHandler(lesson.lesson_id, index)}
+                        onClick={clickHandler(lesson.lesson_id)}
                         isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                       >
                         <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>
@@ -165,11 +169,11 @@ const Chapter: NextPage = () => {
                     <ProgressBar progress={calculateChapterProgeress()} />
                   </div>
                 </li>
-                {chapter?.lessons.map((lesson, index) => {
+                {chapter?.lessons.map((lesson) => {
                   return (
                     <StyleSideBarList
                       key={lesson.lesson_id}
-                      onClick={clickHandler(lesson.lesson_id, index)}
+                      onClick={clickHandler(lesson.lesson_id)}
                       isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                     >
                       <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>

--- a/pages/course.tsx
+++ b/pages/course.tsx
@@ -108,7 +108,7 @@ const Course: NextPage = () => {
                             <Link
                               href={{
                                 pathname: '/chapter',
-                                query: { attendanceId, chapterId: chapter.chapter_id, selectId: index },
+                                query: { attendanceId, chapterId: chapter.chapter_id, lessonIndex: index },
                               }}
                               as={`/chapter?attendanceId=${attendanceId}&chapterId=${chapter.chapter_id}`}
                             >

--- a/pages/course.tsx
+++ b/pages/course.tsx
@@ -102,11 +102,15 @@ const Course: NextPage = () => {
                   <div key={chapter.chapter_id}>
                     <ChapterTitleCard title={chapter.title} />
                     <div className="my-[50px] mx-auto w-11/12 text-center">
-                      {chapter.lessons.map((lesson) => {
+                      {chapter.lessons.map((lesson, index) => {
                         return (
                           <div className="my-5" key={lesson.lesson_id}>
                             <Link
-                              href={{ pathname: '/chapter', query: { attendanceId, chapterId: chapter.chapter_id } }}
+                              href={{
+                                pathname: '/chapter',
+                                query: { attendanceId, chapterId: chapter.chapter_id, selectId: index },
+                              }}
+                              as={`/chapter?attendanceId=${attendanceId}&chapterId=${chapter.chapter_id}`}
                             >
                               <a>
                                 <TitleStatusCard status={lesson.lessonAttendance.status} title={lesson.title} />


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-290

## やったこと
＜機能実装＞
- 講座一覧ページを作成する（講師側）


## 確認方法
- `npm install`または、'yarn'
- http://localhost:3000/instructor/course にアクセスする
- instructorのIDが1のユーザーの口座が全て表示されていればOK
