### PR TITLE
講師ログイン画面の実装

### DIFF
--- a/components/InstructorUserDropDown.tsx
+++ b/components/InstructorUserDropDown.tsx
@@ -7,9 +7,9 @@ export const InstructorUserDropDown: FC = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const clickHandler = () => {
-    Axios.post('/logout').then((res) => {
+    Axios.post('/logout/instructor').then((res) => {
       if (res.status === 200) {
-        Router.push('/login');
+        Router.push('/instructor/login');
       }
     });
   };

--- a/components/InstructorUserDropDown.tsx
+++ b/components/InstructorUserDropDown.tsx
@@ -1,0 +1,18 @@
+import React, { FC, useState } from 'react';
+import { Axios } from '@/lib/api';
+import Router from 'next/router';
+import { UserDropDown } from './presentations/UserDropDown';
+
+export const InstructorUserDropDown: FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const clickHandler = () => {
+    Axios.post('/logout').then((res) => {
+      if (res.status === 200) {
+        Router.push('/login');
+      }
+    });
+  };
+
+  return <UserDropDown isOpen={isOpen} setIsOpen={setIsOpen} logoutHandler={clickHandler} />;
+};

--- a/components/StudentUserDropDown.tsx
+++ b/components/StudentUserDropDown.tsx
@@ -1,0 +1,18 @@
+import React, { FC, useState } from 'react';
+import { Axios } from '@/lib/api';
+import Router from 'next/router';
+import { UserDropDown } from './presentations/UserDropDown';
+
+export const StudentUserDropDown: FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const clickHandler = () => {
+    Axios.post('/logout').then((res) => {
+      if (res.status === 200) {
+        Router.push('/login');
+      }
+    });
+  };
+
+  return <UserDropDown isOpen={isOpen} setIsOpen={setIsOpen} logoutHandler={clickHandler} />;
+};

--- a/components/layouts/InstructorHeader.tsx
+++ b/components/layouts/InstructorHeader.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+import { InstructorUserDropDown } from '../InstructorUserDropDown';
+import { Header } from './presentations/Header';
+
+type Props = {
+  isLogin?: boolean;
+};
+
+export const InstructorHeader: FC<Props> = ({ isLogin = true }) => {
+  return <Header isLogin={isLogin} renderUserDropDown={() => <InstructorUserDropDown />} />;
+};

--- a/components/layouts/StudentHeader.tsx
+++ b/components/layouts/StudentHeader.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+import { StudentUserDropDown } from '../StudentUserDropDown';
+import { Header } from './presentations/Header';
+
+type Props = {
+  isLogin?: boolean;
+};
+
+export const StudentHeader: FC<Props> = ({ isLogin = true }) => {
+  return <Header isLogin={isLogin} renderUserDropDown={() => <StudentUserDropDown />} />;
+};

--- a/components/layouts/presentations/Header.tsx
+++ b/components/layouts/presentations/Header.tsx
@@ -1,11 +1,11 @@
-import { FC } from 'react';
-import { UserDropDown } from '../elements/UserDropDown';
+import React, { FC, ReactNode } from 'react';
 
 type Props = {
   isLogin?: boolean;
+  renderUserDropDown: () => ReactNode;
 };
 
-export const Header: FC<Props> = ({ isLogin = true }) => {
+export const Header: FC<Props> = ({ isLogin = true, renderUserDropDown }) => {
   return (
     <nav className="w-full bg-primary h-24 sticky top-0 z-50">
       <div className="flex min-h-full justify-between">
@@ -14,7 +14,7 @@ export const Header: FC<Props> = ({ isLogin = true }) => {
             <h1 className="font-bold text-3xl text-[#FBF459]">受講管理アプリ</h1>
           </a>
         </div>
-        {isLogin && <UserDropDown />}
+        {isLogin && renderUserDropDown()}
       </div>
     </nav>
   );

--- a/components/presentations/UserDropDown.tsx
+++ b/components/presentations/UserDropDown.tsx
@@ -1,19 +1,13 @@
 import React, { FC, useState } from 'react';
 import clsx from 'clsx';
-import { Axios } from '@/lib/api';
-import Router from 'next/router';
 
-export const UserDropDown: FC = () => {
-  const [isOpen, setIsOpen] = useState(false);
+type Props = {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  logoutHandler: () => void;
+};
 
-  const clickHandler = () => {
-    Axios.post('/logout').then((res) => {
-      if (res.status === 200) {
-        Router.push('/login');
-      }
-    });
-  };
-
+export const UserDropDown: FC<Props> = ({ isOpen, setIsOpen, logoutHandler }) => {
   return (
     <div className="mr-5 relative inline-block top-5">
       <button onClick={() => setIsOpen(!isOpen)}>
@@ -32,7 +26,7 @@ export const UserDropDown: FC = () => {
           <a href="#" className="text-gray-700 block px-4 py-2 text-sm">
             ユーザー情報編集
           </a>
-          <button className="text-gray-700 px-4 py-2 text-sm w-full text-start" onClick={clickHandler}>
+          <button className="text-gray-700 px-4 py-2 text-sm w-full text-start" onClick={logoutHandler}>
             ログアウト
           </button>
         </div>

--- a/features/course/hooks/useFetchInstructorCourses.ts
+++ b/features/course/hooks/useFetchInstructorCourses.ts
@@ -1,25 +1,31 @@
-import { Axios } from '@/lib/api';
 import { Course } from '@/features/course/types/Course';
-import { useEffect, useState } from 'react';
+import { Instructor } from '@/features/instructor/types/Instructor';
+import { Attendance } from '@/features/attendance/types/Attendance';
+import { fetcher } from '@/lib/Fetcher';
+import useSWR from 'swr';
+import { useState } from 'react';
 
-export const useFetchInstructorCourses = (args: {
-  setIsLoading: (value: React.SetStateAction<boolean>) => void;
-  setIsError: (value: React.SetStateAction<boolean>) => void;
-}) => {
-  const { setIsLoading, setIsError } = args;
-  const [instructorCourses, setInstructorCourses] = useState<Course[]>([]);
+type Data = Course & {
+  instructor: Instructor;
+  attendance: Attendance;
+};
 
-  useEffect(() => {
-    Axios.get('/api/v1/instructor/course/index')
-      .then((res) => {
-        setInstructorCourses(res.data.data);
-        setIsLoading(false);
-      })
-      .catch((error) => {
-        console.error(error);
-        setIsLoading(false);
-        setIsError(true);
-      });
-  }, [setIsLoading, setIsError]);
-  return [instructorCourses] as const;
+export const useFetchInstructorCourses = () => {
+  const [text, setText] = useState('');
+  const updateText = (text: string) => setText(text);
+
+  const {
+    data: courses,
+    isLoading,
+    error,
+  } = useSWR<{
+    data: Data[];
+  }>(text ? `/api/v1/instructor/course/index?text=${text}` : '/api/v1/instructor/course/index', fetcher);
+
+  return {
+    courses: courses?.data,
+    isLoading,
+    error,
+    updateText,
+  };
 };

--- a/features/login/components/InstructorAuthWrapper.tsx
+++ b/features/login/components/InstructorAuthWrapper.tsx
@@ -1,0 +1,28 @@
+import { FC, ReactNode, useEffect } from 'react';
+import useSWR from 'swr';
+import { fetcher } from '@/lib/Fetcher';
+import { Loading } from '@/components/utils/Loading';
+import Router from 'next/router';
+
+type Props = {
+  children: ReactNode;
+};
+
+export const InstructorAuthWrapper: FC<Props> = ({ children }) => {
+  const { isValidating, error } = useSWR('/api/user', fetcher);
+
+  useEffect(() => {
+    if (!isValidating && error) {
+      Router.push('/instructor/login');
+    }
+  }, [isValidating, error]);
+
+  if (isValidating)
+    return (
+      <div className="w-3/4 mx-auto min-h-[100vh] mt-10 mb-10">
+        <Loading />
+      </div>
+    );
+
+  return <>{children}</>;
+};

--- a/features/login/components/InstructorLoginForm.tsx
+++ b/features/login/components/InstructorLoginForm.tsx
@@ -1,0 +1,58 @@
+import { FC, useRef, useState } from 'react';
+import { LoginFormSchema } from '@/features/login/schema/LoginFormSchema';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Axios } from '@/lib/api';
+import Router from 'next/router';
+import { LoginForm } from './presentations/LoginForm';
+
+export const InstructorLoginForm: FC = () => {
+  const [isUnauthorized, setIsUnauthorized] = useState<boolean>(false);
+  const isSending = useRef<boolean>(false);
+
+  const defaultValues = {
+    email: '',
+    password: '',
+  };
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm({
+    mode: 'onSubmit',
+    resolver: yupResolver(LoginFormSchema),
+    defaultValues,
+  });
+
+  const submitHandler = (data: typeof defaultValues) => {
+    isSending.current = true;
+    Axios.get('/sanctum/csrf-cookie').then(() => {
+      Axios.post('/login/instructor', data)
+        .then((res) => {
+          isSending.current = false;
+          setValue('password', '');
+          if (res.data.result === true) {
+            Router.push('/instructor/courses');
+          }
+        })
+        .catch((error) => {
+          isSending.current = false;
+          setValue('password', '');
+          if (error.response.status === 401) {
+            setIsUnauthorized(true);
+          }
+        });
+    });
+  };
+
+  return (
+    <LoginForm
+      isUnauthorized={isUnauthorized}
+      isLoading={isSending.current}
+      onSubmit={handleSubmit(submitHandler)}
+      errors={errors}
+      register={register}
+    />
+  );
+};

--- a/features/login/components/StudentLoginForm.tsx
+++ b/features/login/components/StudentLoginForm.tsx
@@ -1,0 +1,58 @@
+import { FC, useRef, useState } from 'react';
+import { LoginFormSchema } from '@/features/login/schema/LoginFormSchema';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Axios } from '@/lib/api';
+import Router from 'next/router';
+import { LoginForm } from './presentations/LoginForm';
+
+export const StudentLoginForm: FC = () => {
+  const [isUnauthorized, setIsUnauthorized] = useState<boolean>(false);
+  const isSending = useRef<boolean>(false);
+
+  const defaultValues = {
+    email: '',
+    password: '',
+  };
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm({
+    mode: 'onSubmit',
+    resolver: yupResolver(LoginFormSchema),
+    defaultValues,
+  });
+
+  const submitHandler = (data: typeof defaultValues) => {
+    isSending.current = true;
+    Axios.get('/sanctum/csrf-cookie').then(() => {
+      Axios.post('/login', data)
+        .then((res) => {
+          isSending.current = false;
+          setValue('password', '');
+          if (res.data.result === true) {
+            Router.push('/courses');
+          }
+        })
+        .catch((error) => {
+          isSending.current = false;
+          setValue('password', '');
+          if (error.response.status === 401) {
+            setIsUnauthorized(true);
+          }
+        });
+    });
+  };
+
+  return (
+    <LoginForm
+      isUnauthorized={isUnauthorized}
+      isLoading={isSending.current}
+      onSubmit={handleSubmit(submitHandler)}
+      errors={errors}
+      register={register}
+    />
+  );
+};

--- a/features/login/components/presentations/LoginForm.tsx
+++ b/features/login/components/presentations/LoginForm.tsx
@@ -1,53 +1,23 @@
-import { FC, useState } from 'react';
-import { LoginFormSchema } from '@/features/login/schema/LoginFormSchema';
-import { useForm } from 'react-hook-form';
-import { yupResolver } from '@hookform/resolvers/yup';
-import { Axios } from '@/lib/api';
-import Router from 'next/router';
+import { FC } from 'react';
 import { Button } from '@/components/elements/Button';
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
 
-export const LoginForm: FC = () => {
-  const [isUnauthorized, setIsUnauthorized] = useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState(false);
-
-  const defaultValues = {
-    email: '',
-    password: '',
-  };
-  const {
-    register,
-    handleSubmit,
-    setValue,
-    formState: { errors },
-  } = useForm({
-    mode: 'onSubmit',
-    resolver: yupResolver(LoginFormSchema),
-    defaultValues,
-  });
-
-  const submitHandler = (data: typeof defaultValues) => {
-    setIsLoading(true);
-    Axios.get('/sanctum/csrf-cookie').then(() => {
-      Axios.post('/login', data)
-        .then((res) => {
-          setIsLoading(false);
-          setValue('password', '');
-          if (res.data.result === true) {
-            Router.push('/courses');
-          }
-        })
-        .catch((error) => {
-          setIsLoading(false);
-          setValue('password', '');
-          if (error.response.status === 401) {
-            setIsUnauthorized(true);
-          }
-        });
-    });
-  };
-
+type Props = {
+  isUnauthorized: boolean;
+  isLoading: boolean;
+  onSubmit: () => void;
+  errors: FieldErrors<{
+    email: string;
+    password: string;
+  }>;
+  register: UseFormRegister<{
+    email: string;
+    password: string;
+  }>;
+};
+export const LoginForm: FC<Props> = ({ isUnauthorized, isLoading, onSubmit, errors, register }) => {
   return (
-    <form className="md:w-1/3 md:border mx-auto min-h-full my-10 bg-white" onSubmit={handleSubmit(submitHandler)}>
+    <form className="md:w-1/3 md:border mx-auto min-h-full my-10 bg-white" onSubmit={onSubmit}>
       <h2 className="text-center mt-10 text-2xl">ログイン画面</h2>
       <div className="w-4/5 mx-auto">
         {isUnauthorized && <div className="text-red-600 mt-2 text-center">ログインに失敗しました</div>}

--- a/pages/chapter.tsx
+++ b/pages/chapter.tsx
@@ -1,4 +1,4 @@
-import { Header } from '@/components/layouts/Header';
+import { StudentHeader } from '@/components/layouts/StudentHeader';
 import { ToggleButton } from '@/components/elements/ToggleButton';
 import { ProgressBar } from '@/components/elements/ProgressBar';
 import { SideBar } from '@/components/elements/SideBar';
@@ -123,7 +123,7 @@ const Chapter: NextPage = () => {
 
   return (
     <AuthWrapper>
-      <Header />
+      <StudentHeader />
       <div className="flex">
         {isLoading ? (
           <div className="w-3/4 mx-auto min-h-[100vh] mt-10 mb-10">

--- a/pages/course.tsx
+++ b/pages/course.tsx
@@ -1,4 +1,4 @@
-import { Header } from '@/components/layouts/Header';
+import { StudentHeader } from '@/components/layouts/StudentHeader';
 import { ToggleButton } from '@/components/elements/ToggleButton';
 import { SideBar } from '@/components/elements/SideBar';
 import { Thumbnail } from '@/components/elements/Thumbnail';
@@ -38,7 +38,7 @@ const Course: NextPage = () => {
 
   return (
     <AuthWrapper>
-      <Header />
+      <StudentHeader />
       <div className="flex">
         {isLoading && (
           <div className="w-3/4 mx-auto min-h-[100vh] my-10">

--- a/pages/courses.tsx
+++ b/pages/courses.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { NextPage } from 'next';
-import { Header } from '@/components/layouts/Header';
+import { StudentHeader } from '@/components/layouts/StudentHeader';
 import { useFetchCourses } from '@/hooks/useFetchCourses';
 import { CourseCard } from '@/features/course/components/CourseCard';
 import { CourseHeader } from '@/features/course/components/CourseHeader';
@@ -15,7 +15,7 @@ const Courses: NextPage = () => {
 
   return (
     <AuthWrapper>
-      <Header />
+      <StudentHeader />
       <CourseHeader updateText={updateText} />
       {isLoading && <Loading />}
       {error && <Error />}

--- a/pages/instructor/course/edit.tsx
+++ b/pages/instructor/course/edit.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/elements/Button';
 import { SwitchButton } from '@/components/elements/SwitchButton';
 import { Thumbnail } from '@/components/elements/Thumbnail';
-import { Header } from '@/components/layouts/Header';
+import { InstructorHeader } from '@/components/layouts/InstructorHeader';
 import { Loading } from '@/components/utils/Loading';
 import { FormLayout } from '@/features/course/components/FormLayout';
 import { useFetchInstructorCourse } from '@/features/course/hooks/useFetchInstructorCourse';
@@ -94,7 +94,7 @@ const Edit: NextPage = () => {
       )}
       {course && (
         <>
-          <Header />
+          <InstructorHeader />
           <FormLayout>
             <form onSubmit={submitHandler}>
               <h2 className="text-center text-2xl py-8">講座編集</h2>

--- a/pages/instructor/course/register.tsx
+++ b/pages/instructor/course/register.tsx
@@ -1,4 +1,4 @@
-import { Header } from '@/components/layouts/Header';
+import { InstructorHeader } from '@/components/layouts/InstructorHeader';
 import { NextPage } from 'next';
 import { useDropzone } from 'react-dropzone';
 import { useForm } from 'react-hook-form';
@@ -57,7 +57,7 @@ const Register: NextPage = () => {
 
   return (
     <>
-      <Header />
+      <InstructorHeader />
       <FormLayout>
         <form onSubmit={handleSubmit(submitHandler)}>
           <h2 className="text-center text-2xl py-8">講座登録</h2>

--- a/pages/instructor/courses.tsx
+++ b/pages/instructor/courses.tsx
@@ -7,12 +7,13 @@ import { CourseCard } from '@/features/course/components/CourseCard';
 import { CourseHeader } from '@/features/course/components/CourseHeader';
 import { Thumbnail } from '@/components/elements/Thumbnail';
 import { CourseTitle } from '@/features/course/components/CourseTitle';
+import { InstructorAuthWrapper } from '@/features/login/components/InstructorAuthWrapper';
 
 const InstructorCourses: NextPage = () => {
   const { courses, isLoading, error, updateText } = useFetchInstructorCourses();
 
   return (
-    <>
+    <InstructorAuthWrapper>
       <InstructorHeader />
       <CourseHeader updateText={updateText} />
       <div className="container mx-auto mb-10">
@@ -38,7 +39,7 @@ const InstructorCourses: NextPage = () => {
           })}
         </div>
       </div>
-    </>
+    </InstructorAuthWrapper>
   );
 };
 

--- a/pages/instructor/courses.tsx
+++ b/pages/instructor/courses.tsx
@@ -1,6 +1,5 @@
 import { NextPage } from 'next';
-import { useState } from 'react';
-import { Header } from '@/components/layouts/Header';
+import { InstructorHeader } from '@/components/layouts/InstructorHeader';
 import { Loading } from '@/components/utils/Loading';
 import { useFetchInstructorCourses } from '@/features/course/hooks/useFetchInstructorCourses';
 import { Error } from '@/components/utils/Error';
@@ -10,39 +9,34 @@ import { Thumbnail } from '@/components/elements/Thumbnail';
 import { CourseTitle } from '@/features/course/components/CourseTitle';
 
 const InstructorCourses: NextPage = () => {
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [isError, setIsError] = useState<boolean>(false);
-  const [courses] = useFetchInstructorCourses({ setIsLoading, setIsError });
+  const { courses, isLoading, error, updateText } = useFetchInstructorCourses();
 
   return (
     <>
-      <Header />
-      <CourseHeader />
+      <InstructorHeader />
+      <CourseHeader updateText={updateText} />
       <div className="container mx-auto mb-10">
-        {isLoading ? (
-          <Loading />
-        ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-[30px]">
-            {courses.map((course) => {
-              return (
-                <CourseCard key={course.course_id}>
-                  <div className="h-auto">
-                    <Thumbnail
-                      src={process.env.NEXT_PUBLIC_IMAGE_URL + course.image}
-                      alt="children"
-                      height={360}
-                      width={640}
-                    />
-                  </div>
-                  <div className="h-auto  ml-[13px] mt-[16px]">
-                    <CourseTitle course={course} />
-                  </div>
-                </CourseCard>
-              );
-            })}
-          </div>
-        )}
-        {isError && <Error />}
+        {isLoading && <Loading />}
+        {error && <Error />}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-[30px]">
+          {courses?.map((course) => {
+            return (
+              <CourseCard key={course.course_id}>
+                <div className="h-auto">
+                  <Thumbnail
+                    src={process.env.NEXT_PUBLIC_IMAGE_URL + course.image}
+                    alt="children"
+                    height={360}
+                    width={640}
+                  />
+                </div>
+                <div className="h-auto  ml-[13px] mt-[16px]">
+                  <CourseTitle course={course} />
+                </div>
+              </CourseCard>
+            );
+          })}
+        </div>
       </div>
     </>
   );

--- a/pages/instructor/login.tsx
+++ b/pages/instructor/login.tsx
@@ -1,0 +1,14 @@
+import { InstructorHeader } from '@/components/layouts/InstructorHeader';
+import { InstructorLoginForm } from '@/features/login/components/InstructorLoginForm';
+import { NextPage } from 'next';
+
+const Login: NextPage = () => {
+  return (
+    <>
+      <InstructorHeader isLogin={false} />
+      <InstructorLoginForm />
+    </>
+  );
+};
+
+export default Login;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,12 +1,12 @@
-import { Header } from '@/components/layouts/Header';
-import { LoginForm } from '@/features/login/components/LoginForm';
+import { StudentHeader } from '@/components/layouts/StudentHeader';
+import { StudentLoginForm } from '@/features/login/components/StudentLoginForm';
 import { NextPage } from 'next';
 
 const Login: NextPage = () => {
   return (
     <>
-      <Header isLogin={false} />
-      <LoginForm />
+      <StudentHeader isLogin={false} />
+      <StudentLoginForm />
     </>
   );
 };


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-494

## やったこと
- 講師ログインAPIとの連携
- ログインフォームを講師と生徒でContainer/Presenterパターンで実装
- ヘッダーを講師と生徒でContainer/Presenterパターンで実装
- 講師ログアウトAPIとの連携

## 確認方法
- http://localhost:3000/instructor/login にアクセス
- test_instructor@example.comとpasswordでログイン
- 講師講座一覧画面へリダイレクト