### PR TITLE
講師側レッスン編集画面の実装

### DIFF
--- a/components/elements/SideBarList.tsx
+++ b/components/elements/SideBarList.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const StyleSideBarList = styled.li<{ isSelected: boolean }>`
+  border-top: 1px solid #b5b5b5;
+  min-height: 4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: ${({ isSelected }) => isSelected && '#ddd'};
+  cursor: pointer;
+  padding: 0.5rem;
+  :hover {
+    opacity: 0.8;
+  }
+`;
+
+type Props = {
+  onClick: () => void;
+  isSelected: boolean;
+  children: React.ReactNode;
+};
+
+export const SideBarList: React.FC<Props> = ({
+  onClick,
+  isSelected,
+  children,
+}) => {
+  return (
+    <StyleSideBarList onClick={onClick} isSelected={isSelected}>
+      <p className="text-xl	text-[#6D8DFF]">{children}</p>
+    </StyleSideBarList>
+  );
+};

--- a/components/elements/SwitchButton.tsx
+++ b/components/elements/SwitchButton.tsx
@@ -53,7 +53,12 @@ const StyledSwitch = styled.div`
 export const SwitchButton: React.FC<Props> = ({ checked, onChange }) => {
   return (
     <StyledSwitch>
-      <Checkbox id="checkbox" type="checkbox" defaultChecked={checked} onChange={() => onChange()} />
+      <Checkbox
+        id="checkbox"
+        type="checkbox"
+        defaultChecked={checked}
+        onChange={() => onChange()}
+      />
       <Label htmlFor="checkbox" />
     </StyledSwitch>
   );

--- a/components/utils/Error.tsx
+++ b/components/utils/Error.tsx
@@ -1,6 +1,10 @@
 export const Error = () => {
   return (
-    <div id="alert-2" className="flex p-4 mb-4 bg-red-100 rounded-lg dark:bg-red-200" role="alert">
+    <div
+      id="alert-2"
+      className="flex p-4 mb-4 bg-red-100 rounded-lg dark:bg-red-200"
+      role="alert"
+    >
       <svg
         aria-hidden="true"
         className="flex-shrink-0 w-5 h-5 text-red-700 dark:text-red-800"
@@ -9,9 +13,9 @@ export const Error = () => {
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          fill-rule="evenodd"
+          fillRule="evenodd"
           d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-          clip-rule="evenodd"
+          clipRule="evenodd"
         ></path>
       </svg>
       <span className="sr-only">Info</span>
@@ -25,11 +29,16 @@ export const Error = () => {
         aria-label="Close"
       >
         <span className="sr-only">閉じる</span>
-        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          className="w-5 h-5"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
           <path
-            fill-rule="evenodd"
+            fillRule="evenodd"
             d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-            clip-rule="evenodd"
+            clipRule="evenodd"
           ></path>
         </svg>
       </button>

--- a/features/chapter/hooks/useFetchInstructorChapters.ts
+++ b/features/chapter/hooks/useFetchInstructorChapters.ts
@@ -25,8 +25,6 @@ export const useFetchInstructorChapters = ({ courseId, chapterId }: Params) => {
     }
   );
 
-  console.log(data);
-
   return {
     chapter: data?.data,
     error,

--- a/features/chapter/hooks/useFetchInstructorChapters.ts
+++ b/features/chapter/hooks/useFetchInstructorChapters.ts
@@ -1,0 +1,35 @@
+import { fetcher } from '@/lib/Fetcher';
+import { Chapter } from '../types/Chapter';
+import useSWR from 'swr';
+import { Lesson } from '@/features/lesson/types/Lesson';
+
+type Params = {
+  courseId: string | string[] | undefined;
+  chapterId: string | string[] | undefined;
+};
+
+export const useFetchInstructorChapters = ({ courseId, chapterId }: Params) => {
+  const shouldFetch = courseId !== undefined && chapterId !== undefined;
+
+  const { data, error, isLoading } = useSWR<{
+    data: Chapter & {
+      lessons: Lesson[];
+    };
+  }>(
+    shouldFetch
+      ? `/api/v1/instructor/course/${courseId}/chapter/${chapterId}`
+      : null,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+    }
+  );
+
+  console.log(data);
+
+  return {
+    chapter: data?.data,
+    error,
+    isLoading,
+  };
+};

--- a/features/chapter/hooks/useFetchInstructorChapters.ts
+++ b/features/chapter/hooks/useFetchInstructorChapters.ts
@@ -11,7 +11,7 @@ type Params = {
 export const useFetchInstructorChapters = ({ courseId, chapterId }: Params) => {
   const shouldFetch = courseId !== undefined && chapterId !== undefined;
 
-  const { data, error, isLoading } = useSWR<{
+  const { data, error, isLoading, mutate } = useSWR<{
     data: Chapter & {
       lessons: Lesson[];
     };
@@ -29,5 +29,6 @@ export const useFetchInstructorChapters = ({ courseId, chapterId }: Params) => {
     chapter: data?.data,
     error,
     isLoading,
+    mutate,
   };
 };

--- a/features/instructor/components/EditForm.tsx
+++ b/features/instructor/components/EditForm.tsx
@@ -18,16 +18,10 @@ export const EditForm: React.FC = () => {
     setUploadedFileName(fileName);
   };
 
-  const {
-    handleSubmit,
-    register,
-    control,
-    isDefaultValues,
-    uploadImage,
-    errors,
-  } = usePutForm({
-    instructor,
-  });
+  const { handleSubmit, register, isDefaultValues, uploadImage, errors } =
+    usePutForm({
+      instructor,
+    });
 
   const uploadImageHandler = (file: File | null) => {
     uploadImage(file);

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -1,3 +1,59 @@
-export const EditForm: React.FC = () => {
-  return <form></form>;
+import { SwitchButton } from '@/components/elements/SwitchButton';
+import { Lesson } from '../types/Lesson';
+import { usePutForm } from '../hooks/usePutForm';
+import FieldInput from '@/features/student/components/FieldInput';
+import { Button } from '@/components/elements/Button';
+
+type Props = {
+  lesson: Lesson;
+};
+
+export const EditForm: React.FC<Props> = ({ lesson }) => {
+  const { register } = usePutForm({
+    lesson,
+  });
+
+  return (
+    <form className="md:w-2/3 md:border mx-auto my-10 py-10 bg-white">
+      <h2 className="text-center text-2xl">レッスン編集</h2>
+      <div className="w-4/5 mx-auto">
+        <div className="mt-10">
+          <label htmlFor="title">
+            <p className="font-bold mb-1">レッスンタイトル</p>
+            <FieldInput defaultValue={lesson.title} />
+          </label>
+        </div>
+        <div className="mt-10">
+          <label htmlFor="url">
+            <p className="font-bold mb-1">動画URL</p>
+            <FieldInput defaultValue={lesson.url} {...register('url')} />
+          </label>
+        </div>
+        <div className="mt-10">
+          <p className="font-bold mb-3">非公開/公開</p>
+          <SwitchButton checked={true} onChange={() => {}} />
+        </div>
+        <div className="mt-10">
+          <p className="font-bold mb-3">テキスト</p>
+          <textarea
+            className="p-2 h-40 rounded border-b-2 w-full focus:outline-none focus:border-[#B0ABAB]"
+            defaultValue={lesson.remarks}
+            {...register('remarks')}
+          />
+        </div>
+        <div className="my-5 text-center flex justify-between">
+          <Button
+            type="button"
+            color="danger"
+            className="hover:opacity-75 py-2 px-5"
+          >
+            削除
+          </Button>
+          <Button type="submit" className="hover:opacity-75 py-2 px-5">
+            更新
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
 };

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -81,6 +81,11 @@ export const EditForm: React.FC<Props> = ({
     >
       <h2 className="text-center text-2xl">レッスン編集</h2>
       <div className="w-4/5 mx-auto">
+        <div className="flex justify-end items-center text-sm">
+          <Button type="button" className="py-2 px-5">
+            プレビュー
+          </Button>
+        </div>
         <div className="mt-10">
           <label htmlFor="title">
             <p className="font-bold mb-1">レッスンタイトル</p>

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -68,7 +68,11 @@ export const EditForm: React.FC<Props> = ({
           .catch((e) => {
             isSending.current = false;
             console.error(e);
-            alert('削除に失敗しました');
+            if (e.response.data.message === 'This lesson has attendance.') {
+              alert('受講者がいるため削除できません');
+            } else {
+              alert('削除に失敗しました');
+            }
           });
       });
     }

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -34,7 +34,7 @@ export const EditForm: React.FC<Props> = ({
 
     isSending.current = true;
     await Axios.get('/sanctum/csrf-cookie').then(() => {
-      Axios.patch(
+      Axios.put(
         `/api/v1/instructor/course/${courseId}/chapter/${chapterId}/lesson/${lesson.lesson_id}`,
         data
       )

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -1,0 +1,3 @@
+export const EditForm: React.FC = () => {
+  return <form></form>;
+};

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -1,10 +1,10 @@
 import { SwitchButton } from '@/components/elements/SwitchButton';
 import { LESSON_STATUS, Lesson } from '../types/Lesson';
 import { usePutForm } from '../hooks/usePutForm';
-import FieldInput from '@/features/student/components/FieldInput';
 import { Button } from '@/components/elements/Button';
 import { Axios } from '@/lib/api';
 import { useRef } from 'react';
+import FieldInput from '@/components/elements/FieldInput';
 
 type Props = {
   courseId: number;
@@ -21,7 +21,7 @@ export const EditForm: React.FC<Props> = ({
 }) => {
   const isSending = useRef<boolean>(false);
 
-  const { register, updateValue, handleSubmit } = usePutForm({
+  const { register, updateValue, handleSubmit, errors } = usePutForm({
     lesson,
   });
 
@@ -85,12 +85,18 @@ export const EditForm: React.FC<Props> = ({
           <label htmlFor="title">
             <p className="font-bold mb-1">レッスンタイトル</p>
             <FieldInput defaultValue={lesson.title} {...register('title')} />
+            {errors.title && (
+              <span className="text-red-600">{errors.title.message}</span>
+            )}
           </label>
         </div>
         <div className="mt-10">
           <label htmlFor="url">
             <p className="font-bold mb-1">動画URL</p>
             <FieldInput defaultValue={lesson.url} {...register('url')} />
+            {errors.url && (
+              <span className="text-red-600">{errors.url.message}</span>
+            )}
           </label>
         </div>
         <div className="mt-10">
@@ -111,6 +117,9 @@ export const EditForm: React.FC<Props> = ({
             defaultValue={lesson.remarks}
             {...register('remarks')}
           />
+          {errors.remarks && (
+            <span className="text-red-600">{errors.remarks.message}</span>
+          )}
         </div>
         <div className="my-5 text-center flex justify-between">
           <Button
@@ -124,7 +133,7 @@ export const EditForm: React.FC<Props> = ({
           {isSending.current ? (
             <Button
               type="button"
-              className="w-4/5 py-2 text-lg opacity-50 cursor-not-allowed"
+              className="py-2 px-5 opacity-50 cursor-not-allowed"
               isDisabled={true}
             >
               更新中...

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -1,26 +1,90 @@
 import { SwitchButton } from '@/components/elements/SwitchButton';
-import { Lesson } from '../types/Lesson';
+import { LESSON_STATUS, Lesson } from '../types/Lesson';
 import { usePutForm } from '../hooks/usePutForm';
 import FieldInput from '@/features/student/components/FieldInput';
 import { Button } from '@/components/elements/Button';
+import { Axios } from '@/lib/api';
+import { useRef } from 'react';
 
 type Props = {
+  courseId: number;
+  chapterId: number;
   lesson: Lesson;
+  mutate: () => void;
 };
 
-export const EditForm: React.FC<Props> = ({ lesson }) => {
-  const { register } = usePutForm({
+export const EditForm: React.FC<Props> = ({
+  courseId,
+  chapterId,
+  lesson,
+  mutate,
+}) => {
+  const isSending = useRef<boolean>(false);
+
+  const { register, updateValue, handleSubmit } = usePutForm({
     lesson,
   });
 
+  const updateStatus = (value: string) => {
+    updateValue('status', value);
+  };
+
+  const onSubmit = handleSubmit(async (data) => {
+    if (isSending.current) return;
+
+    isSending.current = true;
+    await Axios.get('/sanctum/csrf-cookie').then(() => {
+      Axios.patch(
+        `/api/v1/instructor/course/${courseId}/chapter/${chapterId}/lesson/${lesson.lesson_id}`,
+        data
+      )
+        .then(() => {
+          isSending.current = false;
+          alert('更新しました');
+          mutate();
+        })
+        .catch((e) => {
+          isSending.current = false;
+          console.error(e);
+          alert('更新に失敗しました');
+        });
+    });
+  });
+
+  const deleteHandler = () => {
+    if (isSending.current) return;
+
+    if (confirm('削除しますか？')) {
+      isSending.current = true;
+      Axios.get('/sanctum/csrf-cookie').then(() => {
+        Axios.delete(
+          `/api/v1/instructor/course/${courseId}/chapter/${chapterId}/lesson/${lesson.lesson_id}`
+        )
+          .then(() => {
+            isSending.current = false;
+            alert('削除しました');
+            mutate();
+          })
+          .catch((e) => {
+            isSending.current = false;
+            console.error(e);
+            alert('削除に失敗しました');
+          });
+      });
+    }
+  };
+
   return (
-    <form className="md:w-2/3 md:border mx-auto my-10 py-10 bg-white">
+    <form
+      className="md:w-2/3 md:border mx-auto my-10 py-10 bg-white"
+      onSubmit={onSubmit}
+    >
       <h2 className="text-center text-2xl">レッスン編集</h2>
       <div className="w-4/5 mx-auto">
         <div className="mt-10">
           <label htmlFor="title">
             <p className="font-bold mb-1">レッスンタイトル</p>
-            <FieldInput defaultValue={lesson.title} />
+            <FieldInput defaultValue={lesson.title} {...register('title')} />
           </label>
         </div>
         <div className="mt-10">
@@ -31,7 +95,14 @@ export const EditForm: React.FC<Props> = ({ lesson }) => {
         </div>
         <div className="mt-10">
           <p className="font-bold mb-3">非公開/公開</p>
-          <SwitchButton checked={true} onChange={() => {}} />
+          <SwitchButton
+            checked={lesson.status === LESSON_STATUS.PUBLIC}
+            onChange={
+              lesson.status === LESSON_STATUS.PUBLIC
+                ? () => updateStatus(LESSON_STATUS.PRIVATE)
+                : () => updateStatus(LESSON_STATUS.PUBLIC)
+            }
+          />
         </div>
         <div className="mt-10">
           <p className="font-bold mb-3">テキスト</p>
@@ -46,12 +117,23 @@ export const EditForm: React.FC<Props> = ({ lesson }) => {
             type="button"
             color="danger"
             className="hover:opacity-75 py-2 px-5"
+            clickHandler={deleteHandler}
           >
             削除
           </Button>
-          <Button type="submit" className="hover:opacity-75 py-2 px-5">
-            更新
-          </Button>
+          {isSending.current ? (
+            <Button
+              type="button"
+              className="w-4/5 py-2 text-lg opacity-50 cursor-not-allowed"
+              isDisabled={true}
+            >
+              更新中...
+            </Button>
+          ) : (
+            <Button type="submit" className="hover:opacity-75 py-2 px-5">
+              更新
+            </Button>
+          )}
         </div>
       </div>
     </form>

--- a/features/lesson/hooks/usePutForm.ts
+++ b/features/lesson/hooks/usePutForm.ts
@@ -9,7 +9,12 @@ type Params = {
 };
 
 export const usePutForm = ({ lesson }: Params) => {
-  const { register, handleSubmit, setValue } = useForm<PutLesson>({
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<PutLesson>({
     mode: 'onSubmit',
     resolver: yupResolver(PutSchema),
     defaultValues: {
@@ -31,5 +36,6 @@ export const usePutForm = ({ lesson }: Params) => {
     register,
     handleSubmit,
     updateValue,
+    errors,
   };
 };

--- a/features/lesson/hooks/usePutForm.ts
+++ b/features/lesson/hooks/usePutForm.ts
@@ -1,0 +1,36 @@
+import { useForm } from 'react-hook-form';
+import { Lesson } from '../types/Lesson';
+import { PutLesson } from '../types/PutLesson';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { PutSchema } from '../schemas/PutSchema';
+import { useEffect, useState } from 'react';
+
+type Params = {
+  lesson: Lesson;
+};
+
+export const usePutForm = ({ lesson }: Params) => {
+  const [isDefaultValues, setIsDefaultValues] = useState(false);
+
+  const { register, handleSubmit } = useForm<PutLesson>({
+    mode: 'onSubmit',
+    resolver: yupResolver(PutSchema),
+  });
+
+  useEffect(() => {
+    if (lesson === undefined) return;
+    if (isDefaultValues) return;
+
+    register('remarks');
+    register('title');
+    register('url');
+    register('status');
+    setIsDefaultValues(true);
+  }, [lesson]);
+
+  return {
+    register,
+    handleSubmit,
+    isDefaultValues,
+  };
+};

--- a/features/lesson/hooks/usePutForm.ts
+++ b/features/lesson/hooks/usePutForm.ts
@@ -3,34 +3,33 @@ import { Lesson } from '../types/Lesson';
 import { PutLesson } from '../types/PutLesson';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { PutSchema } from '../schemas/PutSchema';
-import { useEffect, useState } from 'react';
 
 type Params = {
   lesson: Lesson;
 };
 
 export const usePutForm = ({ lesson }: Params) => {
-  const [isDefaultValues, setIsDefaultValues] = useState(false);
-
-  const { register, handleSubmit } = useForm<PutLesson>({
+  const { register, handleSubmit, setValue } = useForm<PutLesson>({
     mode: 'onSubmit',
     resolver: yupResolver(PutSchema),
+    defaultValues: {
+      title: lesson.title,
+      remarks: lesson.remarks,
+      url: lesson.url,
+      status: lesson.status,
+    },
   });
 
-  useEffect(() => {
-    if (lesson === undefined) return;
-    if (isDefaultValues) return;
-
-    register('remarks');
-    register('title');
-    register('url');
-    register('status');
-    setIsDefaultValues(true);
-  }, [lesson]);
+  const updateValue = (
+    key: keyof PutLesson,
+    value: PutLesson[keyof PutLesson]
+  ) => {
+    setValue(key, value);
+  };
 
   return {
     register,
     handleSubmit,
-    isDefaultValues,
+    updateValue,
   };
 };

--- a/features/lesson/schemas/PutSchema.ts
+++ b/features/lesson/schemas/PutSchema.ts
@@ -1,0 +1,9 @@
+import * as yup from 'yup';
+import { PutLesson } from '../types/PutLesson';
+
+export const PutSchema: yup.Schema<PutLesson> = yup.object().shape({
+  title: yup.string().required(),
+  remarks: yup.string().required(),
+  url: yup.string().required(),
+  status: yup.string().required(),
+});

--- a/features/lesson/schemas/PutSchema.ts
+++ b/features/lesson/schemas/PutSchema.ts
@@ -2,7 +2,10 @@ import * as yup from 'yup';
 import { PutLesson } from '../types/PutLesson';
 
 export const PutSchema: yup.Schema<PutLesson> = yup.object().shape({
-  title: yup.string().required('タイトルは必須です'),
+  title: yup
+    .string()
+    .max(50, 'タイトルは50文字以内です')
+    .required('タイトルは必須です'),
   remarks: yup.string().required('テキストは必須です'),
   url: yup.string().required('URLは必須です'),
   status: yup.string().required('状態は必須です'),

--- a/features/lesson/schemas/PutSchema.ts
+++ b/features/lesson/schemas/PutSchema.ts
@@ -2,8 +2,8 @@ import * as yup from 'yup';
 import { PutLesson } from '../types/PutLesson';
 
 export const PutSchema: yup.Schema<PutLesson> = yup.object().shape({
-  title: yup.string().required(),
-  remarks: yup.string().required(),
-  url: yup.string().required(),
-  status: yup.string().required(),
+  title: yup.string().required('タイトルは必須です'),
+  remarks: yup.string().required('テキストは必須です'),
+  url: yup.string().required('URLは必須です'),
+  status: yup.string().required('状態は必須です'),
 });

--- a/features/lesson/types/Lesson.ts
+++ b/features/lesson/types/Lesson.ts
@@ -3,4 +3,5 @@ export type Lesson = {
   remarks: string;
   title: string;
   url: string;
+  status: 'private' | 'public';
 };

--- a/features/lesson/types/Lesson.ts
+++ b/features/lesson/types/Lesson.ts
@@ -3,5 +3,12 @@ export type Lesson = {
   remarks: string;
   title: string;
   url: string;
-  status: 'private' | 'public';
+  status: LESSON_STATUS;
 };
+
+export const LESSON_STATUS = {
+  PUBLIC: 'public',
+  PRIVATE: 'private',
+} as const;
+
+export type LESSON_STATUS = typeof LESSON_STATUS[keyof typeof LESSON_STATUS];

--- a/features/lesson/types/PutLesson.ts
+++ b/features/lesson/types/PutLesson.ts
@@ -1,0 +1,5 @@
+import { Lesson } from './Lesson';
+
+export type PutLesson = Pick<Lesson, 'remarks' | 'title' | 'url'> & {
+  status: string;
+};

--- a/pages/instructor/lesson/edit.tsx
+++ b/pages/instructor/lesson/edit.tsx
@@ -107,7 +107,7 @@ const Edit: NextPage = () => {
           <div className="w-3/4 mx-auto min-h-[100vh] mb-10">
             <Breadcrumb links={links} />
             <div className="my-10">
-              <h2 className="font-semibold text-3xl ml-20">{chapter.title}</h2>
+              <h2 className="font-semibold text-3xl">{chapter.title}</h2>
             </div>
             <EditForm
               key={currentLesson.lesson_id}

--- a/pages/instructor/lesson/edit.tsx
+++ b/pages/instructor/lesson/edit.tsx
@@ -3,6 +3,7 @@ import { SideBar } from '@/components/elements/SideBar';
 import { SideBarList } from '@/components/elements/SideBarList';
 import { ToggleButton } from '@/components/elements/ToggleButton';
 import { InstructorHeader } from '@/components/layouts/InstructorHeader';
+import { Error } from '@/components/utils/Error';
 import { useFetchInstructorChapters } from '@/features/chapter/hooks/useFetchInstructorChapters';
 import { EditForm } from '@/features/lesson/components/EditForm';
 import { Lesson } from '@/features/lesson/types/Lesson';
@@ -17,7 +18,7 @@ const Edit: NextPage = () => {
   const [currentLesson, setCurrentLesson] = useState<Lesson | null>(null);
 
   const { course_id, chapter_id } = router.query;
-  const { chapter, isLoading, mutate } = useFetchInstructorChapters({
+  const { chapter, isLoading, error, mutate } = useFetchInstructorChapters({
     courseId: course_id,
     chapterId: chapter_id,
   });
@@ -47,8 +48,9 @@ const Edit: NextPage = () => {
   const courseId = Number(course_id);
   const chapterId = Number(chapter_id);
 
-  // フォームを表示するかどうか
-  const isDisplayForm = !isLoading && currentLesson && courseId && chapterId;
+  // コンテンツを表示するかどうか
+  const isDisplay =
+    !isLoading && currentLesson && courseId && chapterId && chapter;
 
   useEffect(() => {
     if (chapter?.lessons.length) {
@@ -60,39 +62,40 @@ const Edit: NextPage = () => {
   return (
     <>
       <InstructorHeader />
-      <div className="flex">
-        {isShowedSideBar ? (
-          <SideBar>
-            <ul className="mt-2">
-              {chapter?.lessons.map((lesson) => {
-                return (
-                  <SideBarList
-                    key={lesson.lesson_id}
-                    onClick={clickHandler(lesson.lesson_id)}
-                    isSelected={lesson.lesson_id === currentLesson?.lesson_id}
-                  >
-                    {lesson.title}
-                  </SideBarList>
-                );
-              })}
-            </ul>
+      {error && <Error />}
+      {isDisplay && (
+        <div className="flex">
+          {isShowedSideBar ? (
+            <SideBar>
+              <ul className="mt-2">
+                {chapter.lessons.map((lesson) => {
+                  return (
+                    <SideBarList
+                      key={lesson.lesson_id}
+                      onClick={clickHandler(lesson.lesson_id)}
+                      isSelected={lesson.lesson_id === currentLesson?.lesson_id}
+                    >
+                      {lesson.title}
+                    </SideBarList>
+                  );
+                })}
+              </ul>
+              <ToggleButton
+                isShowedSideBar={isShowedSideBar}
+                setIsShowedSideBar={setIsShowedSideBar}
+              />
+            </SideBar>
+          ) : (
             <ToggleButton
               isShowedSideBar={isShowedSideBar}
               setIsShowedSideBar={setIsShowedSideBar}
             />
-          </SideBar>
-        ) : (
-          <ToggleButton
-            isShowedSideBar={isShowedSideBar}
-            setIsShowedSideBar={setIsShowedSideBar}
-          />
-        )}
-        <div className="w-3/4 mx-auto min-h-[100vh] mb-10">
-          <Breadcrumb links={links} />
-          <div className="my-10">
-            <h2 className="font-semibold text-3xl ml-20">{chapter?.title}</h2>
-          </div>
-          {isDisplayForm && (
+          )}
+          <div className="w-3/4 mx-auto min-h-[100vh] mb-10">
+            <Breadcrumb links={links} />
+            <div className="my-10">
+              <h2 className="font-semibold text-3xl ml-20">{chapter.title}</h2>
+            </div>
             <EditForm
               key={currentLesson.lesson_id}
               courseId={courseId}
@@ -100,9 +103,9 @@ const Edit: NextPage = () => {
               lesson={currentLesson}
               mutate={mutate}
             />
-          )}
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 };

--- a/pages/instructor/lesson/edit.tsx
+++ b/pages/instructor/lesson/edit.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumb } from '@/components/elements/Breadcrumb';
 import { SideBar } from '@/components/elements/SideBar';
+import { SideBarList } from '@/components/elements/SideBarList';
 import { ToggleButton } from '@/components/elements/ToggleButton';
 import { InstructorHeader } from '@/components/layouts/InstructorHeader';
 import { useFetchInstructorChapters } from '@/features/chapter/hooks/useFetchInstructorChapters';
@@ -8,21 +9,6 @@ import { Lesson } from '@/features/lesson/types/Lesson';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import styled from 'styled-components';
-
-const StyleSideBarList = styled.li<{ isSelected: boolean }>`
-  border-top: 1px solid #b5b5b5;
-  min-height: 4rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background-color: ${({ isSelected }) => isSelected && '#ddd'};
-  cursor: pointer;
-  padding: 0.5rem;
-  :hover {
-    opacity: 0.8;
-  }
-`;
 
 const Edit: NextPage = () => {
   const router = useRouter();
@@ -30,8 +16,8 @@ const Edit: NextPage = () => {
   const [isShowedSideBar, setIsShowedSideBar] = useState(true);
   const [currentLesson, setCurrentLesson] = useState<Lesson | null>(null);
 
-  const { course_id, chapter_id, lesson_id } = router.query;
-  const { chapter, isLoading } = useFetchInstructorChapters({
+  const { course_id, chapter_id } = router.query;
+  const { chapter, isLoading, mutate } = useFetchInstructorChapters({
     courseId: course_id,
     chapterId: chapter_id,
   });
@@ -58,6 +44,12 @@ const Edit: NextPage = () => {
     },
   ];
 
+  const courseId = Number(course_id);
+  const chapterId = Number(chapter_id);
+
+  // フォームを表示するかどうか
+  const isDisplayForm = !isLoading && currentLesson && courseId && chapterId;
+
   useEffect(() => {
     if (chapter?.lessons.length) {
       const newLesson = chapter?.lessons[0] as Lesson;
@@ -67,22 +59,20 @@ const Edit: NextPage = () => {
 
   return (
     <>
-      {/* ヘッダー */}
       <InstructorHeader />
       <div className="flex">
-        {/* サイドバー */}
         {isShowedSideBar ? (
           <SideBar>
             <ul className="mt-2">
               {chapter?.lessons.map((lesson) => {
                 return (
-                  <StyleSideBarList
+                  <SideBarList
                     key={lesson.lesson_id}
                     onClick={clickHandler(lesson.lesson_id)}
                     isSelected={lesson.lesson_id === currentLesson?.lesson_id}
                   >
-                    <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>
-                  </StyleSideBarList>
+                    {lesson.title}
+                  </SideBarList>
                 );
               })}
             </ul>
@@ -97,13 +87,20 @@ const Edit: NextPage = () => {
             setIsShowedSideBar={setIsShowedSideBar}
           />
         )}
-        {/* コンテンツ */}
         <div className="w-3/4 mx-auto min-h-[100vh] mb-10">
           <Breadcrumb links={links} />
           <div className="my-10">
             <h2 className="font-semibold text-3xl ml-20">{chapter?.title}</h2>
           </div>
-          {!isLoading && currentLesson && <EditForm lesson={currentLesson} />}
+          {isDisplayForm && (
+            <EditForm
+              key={currentLesson.lesson_id}
+              courseId={courseId}
+              chapterId={chapterId}
+              lesson={currentLesson}
+              mutate={mutate}
+            />
+          )}
         </div>
       </div>
     </>

--- a/pages/instructor/lesson/edit.tsx
+++ b/pages/instructor/lesson/edit.tsx
@@ -17,7 +17,7 @@ const Edit: NextPage = () => {
   const [isShowedSideBar, setIsShowedSideBar] = useState(true);
   const [currentLesson, setCurrentLesson] = useState<Lesson | null>(null);
 
-  const { course_id, chapter_id } = router.query;
+  const { course_id, chapter_id, lesson_id } = router.query;
   const { chapter, isLoading, error, mutate } = useFetchInstructorChapters({
     courseId: course_id,
     chapterId: chapter_id,
@@ -50,11 +50,24 @@ const Edit: NextPage = () => {
 
   // コンテンツを表示するかどうか
   const isDisplay =
-    !isLoading && currentLesson && courseId && chapterId && chapter;
+    !isLoading &&
+    currentLesson &&
+    courseId &&
+    chapterId &&
+    lesson_id &&
+    chapter;
 
   useEffect(() => {
+    // 既に現在のレッスンが設定されている場合は何もしない
+    if (currentLesson) {
+      return;
+    }
+
+    // クエリパラメータのlesson_idがある場合は、そのレッスンを表示する
     if (chapter?.lessons.length) {
-      const newLesson = chapter?.lessons[0] as Lesson;
+      const newLesson = chapter.lessons.find(
+        (lesson) => lesson.lesson_id === Number(lesson_id)
+      ) as Lesson;
       setCurrentLesson(newLesson);
     }
   }, [chapter]);
@@ -63,7 +76,7 @@ const Edit: NextPage = () => {
     <>
       <InstructorHeader />
       {error && <Error />}
-      {isDisplay && (
+      {isDisplay ? (
         <div className="flex">
           {isShowedSideBar ? (
             <SideBar>
@@ -105,6 +118,8 @@ const Edit: NextPage = () => {
             />
           </div>
         </div>
+      ) : (
+        <Error />
       )}
     </>
   );

--- a/pages/instructor/lesson/edit.tsx
+++ b/pages/instructor/lesson/edit.tsx
@@ -1,11 +1,13 @@
+import { Breadcrumb } from '@/components/elements/Breadcrumb';
 import { SideBar } from '@/components/elements/SideBar';
 import { ToggleButton } from '@/components/elements/ToggleButton';
 import { InstructorHeader } from '@/components/layouts/InstructorHeader';
 import { useFetchInstructorChapters } from '@/features/chapter/hooks/useFetchInstructorChapters';
+import { EditForm } from '@/features/lesson/components/EditForm';
 import { Lesson } from '@/features/lesson/types/Lesson';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 const StyleSideBarList = styled.li<{ isSelected: boolean }>`
@@ -29,8 +31,7 @@ const Edit: NextPage = () => {
   const [currentLesson, setCurrentLesson] = useState<Lesson | null>(null);
 
   const { course_id, chapter_id, lesson_id } = router.query;
-
-  const { chapter } = useFetchInstructorChapters({
+  const { chapter, isLoading } = useFetchInstructorChapters({
     courseId: course_id,
     chapterId: chapter_id,
   });
@@ -40,6 +41,29 @@ const Edit: NextPage = () => {
       chapter?.lessons.find((lesson) => lesson.lesson_id === lessonId) ?? null;
     setCurrentLesson(newLesson);
   };
+
+  // パン屑のリンクリスト
+  const links = [
+    {
+      title: '講座一覧',
+      href: '/courses',
+    },
+    {
+      title: '講座詳細',
+      href: '#',
+    },
+    {
+      title: chapter?.title ?? '',
+      href: '#',
+    },
+  ];
+
+  useEffect(() => {
+    if (chapter?.lessons.length) {
+      const newLesson = chapter?.lessons[0] as Lesson;
+      setCurrentLesson(newLesson);
+    }
+  }, [chapter]);
 
   return (
     <>
@@ -75,7 +99,11 @@ const Edit: NextPage = () => {
         )}
         {/* コンテンツ */}
         <div className="w-3/4 mx-auto min-h-[100vh] mb-10">
-          <h2 className="font-semibold text-3xl ml-20">{chapter?.title}</h2>
+          <Breadcrumb links={links} />
+          <div className="my-10">
+            <h2 className="font-semibold text-3xl ml-20">{chapter?.title}</h2>
+          </div>
+          {!isLoading && currentLesson && <EditForm lesson={currentLesson} />}
         </div>
       </div>
     </>

--- a/pages/instructor/lesson/edit.tsx
+++ b/pages/instructor/lesson/edit.tsx
@@ -76,7 +76,7 @@ const Edit: NextPage = () => {
     <>
       <InstructorHeader />
       {error && <Error />}
-      {isDisplay ? (
+      {isDisplay && (
         <div className="flex">
           {isShowedSideBar ? (
             <SideBar>
@@ -118,8 +118,6 @@ const Edit: NextPage = () => {
             />
           </div>
         </div>
-      ) : (
-        <Error />
       )}
     </>
   );

--- a/pages/instructor/lesson/edit.tsx
+++ b/pages/instructor/lesson/edit.tsx
@@ -1,0 +1,85 @@
+import { SideBar } from '@/components/elements/SideBar';
+import { ToggleButton } from '@/components/elements/ToggleButton';
+import { InstructorHeader } from '@/components/layouts/InstructorHeader';
+import { useFetchInstructorChapters } from '@/features/chapter/hooks/useFetchInstructorChapters';
+import { Lesson } from '@/features/lesson/types/Lesson';
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+const StyleSideBarList = styled.li<{ isSelected: boolean }>`
+  border-top: 1px solid #b5b5b5;
+  min-height: 4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: ${({ isSelected }) => isSelected && '#ddd'};
+  cursor: pointer;
+  padding: 0.5rem;
+  :hover {
+    opacity: 0.8;
+  }
+`;
+
+const Edit: NextPage = () => {
+  const router = useRouter();
+
+  const [isShowedSideBar, setIsShowedSideBar] = useState(true);
+  const [currentLesson, setCurrentLesson] = useState<Lesson | null>(null);
+
+  const { course_id, chapter_id, lesson_id } = router.query;
+
+  const { chapter } = useFetchInstructorChapters({
+    courseId: course_id,
+    chapterId: chapter_id,
+  });
+
+  const clickHandler = (lessonId: number) => () => {
+    const newLesson =
+      chapter?.lessons.find((lesson) => lesson.lesson_id === lessonId) ?? null;
+    setCurrentLesson(newLesson);
+  };
+
+  return (
+    <>
+      {/* ヘッダー */}
+      <InstructorHeader />
+      <div className="flex">
+        {/* サイドバー */}
+        {isShowedSideBar ? (
+          <SideBar>
+            <ul className="mt-2">
+              {chapter?.lessons.map((lesson) => {
+                return (
+                  <StyleSideBarList
+                    key={lesson.lesson_id}
+                    onClick={clickHandler(lesson.lesson_id)}
+                    isSelected={lesson.lesson_id === currentLesson?.lesson_id}
+                  >
+                    <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>
+                  </StyleSideBarList>
+                );
+              })}
+            </ul>
+            <ToggleButton
+              isShowedSideBar={isShowedSideBar}
+              setIsShowedSideBar={setIsShowedSideBar}
+            />
+          </SideBar>
+        ) : (
+          <ToggleButton
+            isShowedSideBar={isShowedSideBar}
+            setIsShowedSideBar={setIsShowedSideBar}
+          />
+        )}
+        {/* コンテンツ */}
+        <div className="w-3/4 mx-auto min-h-[100vh] mb-10">
+          <h2 className="font-semibold text-3xl ml-20">{chapter?.title}</h2>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Edit;

--- a/pages/instructor/lesson/edit.tsx
+++ b/pages/instructor/lesson/edit.tsx
@@ -33,10 +33,10 @@ const Edit: NextPage = () => {
   const links = [
     {
       title: '講座一覧',
-      href: '/courses',
+      href: '/instructor/courses',
     },
     {
-      title: '講座詳細',
+      title: 'チャプター&レッスン一覧',
       href: '#',
     },
     {


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-623

## やったこと
- 講師側レッスン編集画面のコーディング
- 更新フォームの実装
- レッスン更新APIリクエストの実装
- レッスン削除APIリクエストの実装

## 確認方法
- 講師でログイン
- 次のURLにアクセス
  - http://localhost:3000/instructor/lesson/edit?course_id=1&chapter_id=2&lesson_id=2

## 考慮事項
- チャプター取得APIでステータスが含まれていない
- レッスン削除APIでレッスン削除されない
- プレビューは未実装
- Figmaと一部デザインを変更

パン屑リストの表記は仮状態ですので、指定があればお願いします