### PR TITLE
add:レッスン編集画面 プレビューボタンを押した先の画面作成

### DIFF
--- a/features/lesson-attendance/types/LessonAttendance.ts
+++ b/features/lesson-attendance/types/LessonAttendance.ts
@@ -1,5 +1,3 @@
-import { Lesson } from '@/features/lesson/types/Lesson';
-
 export type LessonAttendance = {
   lesson_attendance_id: number;
   status: LessonAttendanceStatus;
@@ -15,10 +13,3 @@ export type LessonAttendanceStatus =
   | typeof LESSON_ATTENDANCE_STATUS.STATUS_BEFORE_ATTENDANCE
   | typeof LESSON_ATTENDANCE_STATUS.STATUS_IN_ATTENDANCE
   | typeof LESSON_ATTENDANCE_STATUS.STATUS_COMPLETED_ATTENDANCE;
-
-export type LessonList =  
-  | (Lesson & {
-      lessonAttendance: LessonAttendance;
-      isCurrentLesson: boolean;
-    })
-  | undefined;

--- a/features/lesson-attendance/types/LessonAttendance.ts
+++ b/features/lesson-attendance/types/LessonAttendance.ts
@@ -2,3 +2,7 @@ export type LessonAttendance = {
   lesson_attendance_id: number;
   status: 'before_attendance' | 'in_attendance' | 'completed_attendance';
 };
+
+export type LessonAttendanceStatus = {
+  [lessonId: number]: 'before_attendance' | 'in_attendance' | 'completed_attendance';
+};

--- a/features/lesson-attendance/types/LessonAttendance.ts
+++ b/features/lesson-attendance/types/LessonAttendance.ts
@@ -1,6 +1,8 @@
+import { Lesson } from '@/features/lesson/types/Lesson';
+
 export type LessonAttendance = {
   lesson_attendance_id: number;
-  status: 'before_attendance' | 'in_attendance' | 'completed_attendance';
+  status: LessonAttendanceStatus;
 };
 
 export const LESSON_ATTENDANCE_STATUS = {
@@ -13,3 +15,10 @@ export type LessonAttendanceStatus =
   | typeof LESSON_ATTENDANCE_STATUS.STATUS_BEFORE_ATTENDANCE
   | typeof LESSON_ATTENDANCE_STATUS.STATUS_IN_ATTENDANCE
   | typeof LESSON_ATTENDANCE_STATUS.STATUS_COMPLETED_ATTENDANCE;
+
+export type LessonList =  
+  | (Lesson & {
+      lessonAttendance: LessonAttendance;
+      isCurrentLesson: boolean;
+    })
+  | undefined;

--- a/features/lesson-attendance/types/LessonAttendance.ts
+++ b/features/lesson-attendance/types/LessonAttendance.ts
@@ -3,6 +3,13 @@ export type LessonAttendance = {
   status: 'before_attendance' | 'in_attendance' | 'completed_attendance';
 };
 
-export type LessonAttendanceStatus = {
-  [lessonId: number]: 'before_attendance' | 'in_attendance' | 'completed_attendance';
-};
+export const LESSON_ATTENDANCE_STATUS = {
+  STATUS_BEFORE_ATTENDANCE: 'before_attendance',
+  STATUS_IN_ATTENDANCE: 'in_attendance',
+  STATUS_COMPLETED_ATTENDANCE: 'completed_attendance',
+} as const;
+
+export type LessonAttendanceStatus =
+  | typeof LESSON_ATTENDANCE_STATUS.STATUS_BEFORE_ATTENDANCE
+  | typeof LESSON_ATTENDANCE_STATUS.STATUS_IN_ATTENDANCE
+  | typeof LESSON_ATTENDANCE_STATUS.STATUS_COMPLETED_ATTENDANCE;

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/atoms/Button/Button';
 import { Axios } from '@/lib/api';
 import { useRef } from 'react';
 import FieldInput from '@/components/atoms/Field/FieldInput';
+import Link from 'next/link';
 
 type Props = {
   courseId: number;
@@ -86,7 +87,20 @@ export const EditForm: React.FC<Props> = ({
       <h2 className="text-center text-2xl">レッスン編集</h2>
       <div className="mx-auto w-4/5">
         <div className="flex items-center justify-end text-sm">
-          <Button type="button">プレビュー</Button>
+        <Link
+          href={{
+            pathname: '/instructor/lesson/preview',
+            query: {
+              courseId: courseId,
+              chapterId: chapterId,
+              lessonId: lesson.lesson_id,
+            },
+          }}
+        >
+          <a target='_blank' rel='noopener noreferrer'>
+            <Button type="button">プレビュー</Button>
+          </a>
+        </Link>
         </div>
         <div className="mt-10">
           <label htmlFor="title">

--- a/features/lesson/components/EditForm.tsx
+++ b/features/lesson/components/EditForm.tsx
@@ -87,20 +87,20 @@ export const EditForm: React.FC<Props> = ({
       <h2 className="text-center text-2xl">レッスン編集</h2>
       <div className="mx-auto w-4/5">
         <div className="flex items-center justify-end text-sm">
-        <Link
-          href={{
-            pathname: '/instructor/lesson/preview',
-            query: {
-              courseId: courseId,
-              chapterId: chapterId,
-              lessonId: lesson.lesson_id,
-            },
-          }}
-        >
-          <a target='_blank' rel='noopener noreferrer'>
-            <Button type="button">プレビュー</Button>
-          </a>
-        </Link>
+          <Link
+            href={{
+              pathname: '/instructor/lesson/preview',
+              query: {
+                courseId: courseId,
+                chapterId: chapterId,
+                lessonId: lesson.lesson_id,
+              },
+            }}
+          >
+            <a target="_blank" rel="noopener noreferrer">
+              <Button type="button">プレビュー</Button>
+            </a>
+          </Link>
         </div>
         <div className="mt-10">
           <label htmlFor="title">

--- a/pages/instructor/lesson/preview/index.tsx
+++ b/pages/instructor/lesson/preview/index.tsx
@@ -17,6 +17,7 @@ import { Breadcrumb } from '@/components/atoms/Breadcrumb/Breadcrumb';
 import { Movie } from '@/components/atoms/Movie/Movie';
 import { Button } from '@/components/atoms/Button/Button';
 import { number } from "yup";
+import { LessonAttendanceStatus } from '@/features/lesson-attendance/types/LessonAttendance';
 
 type Query = {
   courseId?: string;
@@ -42,14 +43,6 @@ const StyleSideBarList = styled('li')<{ isSelected: boolean }>`
   }
 `;
 
-const SButton = styled(Button)`
-  font-size: 20px;
-  padding: 0.5rem 1rem;
-  @media (max-width: 640px) {
-    font-size: 13px;
-  }
-`;
-
 const Index: NextPage = () => {
   const [isShowedSideBar, setIsShowedSideBar] = useState(true);
   const [width] = useWindowSize();
@@ -65,13 +58,10 @@ const Index: NextPage = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [currentLesson, setCurrentLesson] = useState<Lesson | null>(null);
   
-  type LessonAttendanceStatus = {
-    [lessonId: number]: 'before_attendance' | 'in_attendance' | 'completed_attendance';
-  };
   const generateLessonAttendanceStatusList = (lessons: Lesson[]) => {
     const lessonAttendanceStatusList: LessonAttendanceStatus = {};
     lessons.forEach(lesson => {
-      lessonAttendanceStatusList[lesson.lesson_id] = 'before_attendance';
+      lessonAttendanceStatusList[lesson.lesson_id] = STATUS_BEFORE_ATTENDANCE;
     });
     return lessonAttendanceStatusList;
   };
@@ -235,23 +225,23 @@ const Index: NextPage = () => {
                 {currentLesson && (
                   <>
                     <div className="flex justify-start">
-                      <SButton type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
+                      <Button type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
                           STATUS_BEFORE_ATTENDANCE ? 'primary' : 'secondary'} 
-                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, "before_attendance")}}>
+                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, STATUS_BEFORE_ATTENDANCE)}}>
                         Lesson未実施
-                      </SButton>
+                      </Button>
                       <span className="ml-10" />
-                      <SButton type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
+                      <Button type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
                           STATUS_IN_ATTENDANCE ? 'primary' : 'secondary'} 
-                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, "in_attendance")}}>
+                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, STATUS_IN_ATTENDANCE)}}>
                         Lesson開始
-                      </SButton>
+                      </Button>
                       <span className="ml-10" />
-                      <SButton type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
+                      <Button type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
                           STATUS_COMPLETED_ATTENDANCE ? 'primary' : 'secondary'} 
-                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, "completed_attendance")}}>
+                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, STATUS_COMPLETED_ATTENDANCE)}}>
                         Lesson開始
-                      </SButton>
+                      </Button>
                     </div>
                   </>
                 )}

--- a/pages/instructor/lesson/preview/index.tsx
+++ b/pages/instructor/lesson/preview/index.tsx
@@ -1,0 +1,272 @@
+import { NextPage } from "next";
+import { InstructorLayout } from '@/components/organisms/header';
+import { InstructorAuthWrapper } from '@/features/login/components/Auth/InstructorAuthWrapper';
+import { useEffect, useState } from 'react';
+import { Loading } from '@/components/utils/Loading';
+import { SideBar } from '@/components/atoms/SideBar/SideBar';
+import { ToggleButton } from '@/components/atoms/Button/ToggleButton';
+import { ProgressBar } from '@/components/atoms/ProgressBar/ProgressBar';
+import styled from 'styled-components';
+import { StatusIcon } from '@/features/lesson/components/StatusIcon';
+import { useWindowSize } from '@/hooks/useWindowSize';
+import { useRouter } from 'next/router';
+import { Lesson } from '@/features/lesson/types/Lesson';
+import { useFetchInstructorChapters } from '@/features/chapter/hooks/useFetchInstructorChapters';
+import { useFetchInstructorCourse } from '@/features/course/hooks/useFetchInstructorCourse';
+import { Breadcrumb } from '@/components/atoms/Breadcrumb/Breadcrumb';
+import { Movie } from '@/components/atoms/Movie/Movie';
+import { Button } from '@/components/atoms/Button/Button';
+import { number } from "yup";
+
+type Query = {
+  courseId?: string;
+  chapterId?: string;
+  lessonId?: number;
+};
+
+const STATUS_BEFORE_ATTENDANCE = 'before_attendance';
+const STATUS_IN_ATTENDANCE = 'in_attendance';
+const STATUS_COMPLETED_ATTENDANCE = 'completed_attendance';
+
+const StyleSideBarList = styled('li')<{ isSelected: boolean }>`
+  border-top: 1px solid #b5b5b5;
+  min-height: 4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: ${({ isSelected }) => isSelected && '#ddd'};
+  cursor: pointer;
+  padding: 0.5rem;
+  :hover {
+    opacity: 0.8;
+  }
+`;
+
+const SButton = styled(Button)`
+  font-size: 20px;
+  padding: 0.5rem 1rem;
+  @media (max-width: 640px) {
+    font-size: 13px;
+  }
+`;
+
+const Index: NextPage = () => {
+  const [isShowedSideBar, setIsShowedSideBar] = useState(true);
+  const [width] = useWindowSize();
+  const router = useRouter();
+  const query: Query = router.query;
+  const { chapter, error, mutate } = useFetchInstructorChapters({
+    courseId: query.courseId,
+    chapterId: query.chapterId,
+  });
+  const { course } = useFetchInstructorCourse({
+    courseId: query.courseId,
+  });
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [currentLesson, setCurrentLesson] = useState<Lesson | null>(null);
+  
+  type LessonAttendanceStatus = {
+    [lessonId: number]: 'before_attendance' | 'in_attendance' | 'completed_attendance';
+  };
+  const generateLessonAttendanceStatusList = (lessons: Lesson[]) => {
+    const lessonAttendanceStatusList: LessonAttendanceStatus = {};
+    lessons.forEach(lesson => {
+      lessonAttendanceStatusList[lesson.lesson_id] = 'before_attendance';
+    });
+    return lessonAttendanceStatusList;
+  };
+  const initialLessonAttendanceStatusList = chapter ? generateLessonAttendanceStatusList(chapter.lessons) : {};
+  const [lessonAttendanceStatusList, setLessonAttendanceStatusList] = useState<LessonAttendanceStatus>(initialLessonAttendanceStatusList);
+  
+  const updateLessonAttendanceStatus = (lessonId: number, status: 'before_attendance' | 'in_attendance' | 'completed_attendance') => {
+    setLessonAttendanceStatusList(prevStatus => {
+      const newStatus = { ...prevStatus };
+      newStatus[lessonId] = status;
+      return newStatus;
+    });
+  };
+
+  const lessonId = query.lessonId ? Number(query.lessonId) : 0;
+  // 進捗は固定の値(0%)
+  const calculateChapterProgeress = 0;
+
+  useEffect(() => {
+    if (chapter !== undefined) {
+      setIsLoading(false);
+      if (currentLesson !== null) {
+        const newLesson = chapter.lessons.find(
+          (lesson) => lesson.lesson_id === currentLesson.lesson_id
+        );
+        if (newLesson) {
+          setCurrentLesson(newLesson);
+        }
+      } else {
+        const initialLesson = chapter?.lessons.find(item => item.lesson_id === lessonId);
+        if (initialLesson) {
+          setCurrentLesson(initialLesson);
+        }
+      }
+    }
+  }, [chapter, currentLesson, lessonId]);
+  
+  // パン屑のリンクリスト
+  const links = [
+    {
+      title: '講座一覧',
+      href: '/instructor/courses',
+    },
+    {
+      title: 'チャプター&レッスン一覧',
+      href: `/instructor/chapters?course_id=${query.courseId}`,
+    },
+    {
+      title: chapter?.title ?? '',
+      href: '#',
+    },
+  ];
+
+  const clickHandler = (lessonId: number) => () => {
+    const newLesson = chapter?.lessons.find(
+      (lesson) => lesson.lesson_id === lessonId
+    ) as (Lesson | null);
+    setCurrentLesson(newLesson);
+  };
+
+  return (
+    <InstructorAuthWrapper>
+      <InstructorLayout>
+        <div className="flex">
+          {isLoading ? (
+            <div className="mx-auto my-10 min-h-[100vh] w-3/4">
+              <Loading />
+            </div>
+          ) : (
+            <>
+              {isShowedSideBar ? (
+                <SideBar>
+                  <ul className="mt-2">
+                    <li className="mb-10">
+                      <div className="text-center">
+                        <p className="mb-3 font-semibold">
+                          チャプター進捗 {calculateChapterProgeress}%
+                        </p>
+                        <ProgressBar progress={calculateChapterProgeress} />
+                      </div>
+                    </li>
+                    {chapter?.lessons.map((lesson) => {
+                      return (
+                        <StyleSideBarList
+                          key={lesson.lesson_id}
+                          onClick={clickHandler(lesson.lesson_id)}
+                          isSelected={
+                            lesson.lesson_id === currentLesson?.lesson_id
+                          }
+                        >
+                          <p className="text-xl	text-[#6D8DFF]">
+                            {lesson.title}
+                          </p>
+                          <StatusIcon
+                            status={lessonAttendanceStatusList[lesson.lesson_id] || 'before_attendance'}
+                            size="small"
+                          />
+                        </StyleSideBarList>
+                      );
+                    })}
+                  </ul>
+                  <ToggleButton
+                    isShowedSideBar={isShowedSideBar}
+                    setIsShowedSideBar={setIsShowedSideBar}
+                  />
+                </SideBar>
+              ) : (
+                <ToggleButton
+                  isShowedSideBar={isShowedSideBar}
+                  setIsShowedSideBar={setIsShowedSideBar}
+                />
+              )}
+              <div className="mx-auto mb-10 min-h-[100vh] w-3/4">
+                <Breadcrumb links={links} />
+                  <div className="mt-10 border-b border-black pb-5">
+                    <h2 className="text-3xl font-semibold md:text-4xl">
+                      {course?.title}
+                    </h2>
+                  </div>
+                  <ul className="my-5 border-b border-black md:hidden">
+                  <li className="mb-10">
+                    <div className="text-center">
+                      <p className="mb-3 font-semibold">
+                        チャプター進捗 {calculateChapterProgeress}%
+                      </p>
+                      <ProgressBar progress={calculateChapterProgeress} />
+                    </div>
+                  </li>
+                  {chapter?.lessons.map((lesson) => {
+                    return (
+                      <StyleSideBarList
+                        key={lesson.lesson_id}
+                        onClick={clickHandler(lesson.lesson_id)}
+                        isSelected={
+                          lesson.lesson_id === currentLesson?.lesson_id
+                        }
+                      >
+                        <p className="text-xl	text-[#6D8DFF]">{lesson.title}</p>
+                        <StatusIcon
+                          status={lessonAttendanceStatusList[lesson.lesson_id] || 'before_attendance'}
+                          size="small"
+                        />
+                      </StyleSideBarList>
+                    );
+                  })}
+                </ul>
+                <div className="mx-auto mt-5">
+                  <h2 className="text-[25px] font-semibold md:text-[30px]">
+                    {currentLesson?.title}
+                  </h2>
+                </div>
+                <div className="my-5 overflow-auto">
+                  {(width as number) > 0 && currentLesson && (
+                    <Movie
+                      videoId={currentLesson.url}
+                      height={(width as number) > 640 ? 405 : 180}
+                      width={(width as number) > 640 ? 720 : 320}
+                    />
+                  )}
+                </div>
+                {currentLesson && (
+                  <>
+                    <div className="flex justify-start">
+                      <SButton type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
+                          STATUS_BEFORE_ATTENDANCE ? 'primary' : 'secondary'} 
+                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, "before_attendance")}}>
+                        Lesson未実施
+                      </SButton>
+                      <span className="ml-10" />
+                      <SButton type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
+                          STATUS_IN_ATTENDANCE ? 'primary' : 'secondary'} 
+                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, "in_attendance")}}>
+                        Lesson開始
+                      </SButton>
+                      <span className="ml-10" />
+                      <SButton type="button" color={lessonAttendanceStatusList[currentLesson?.lesson_id] ===
+                          STATUS_COMPLETED_ATTENDANCE ? 'primary' : 'secondary'} 
+                          clickHandler={() => {updateLessonAttendanceStatus(currentLesson?.lesson_id, "completed_attendance")}}>
+                        Lesson開始
+                      </SButton>
+                    </div>
+                  </>
+                )}
+                <div className="mt-5">
+                  <p className="whitespace-pre-wrap">
+                    {currentLesson?.remarks}
+                  </p>
+                </div>
+              </div>
+            </>
+        )}
+        </div>
+      </InstructorLayout>  
+    </InstructorAuthWrapper>
+  );
+}
+
+export default Index;


### PR DESCRIPTION
## issue
https://gut-familie.atlassian.net/browse/JKA-762

## 概要
React レッスン編集画面 プレビューボタンを押した先の画面作成

##動作確認手順
① 講座一覧　>　チャプター&レッスン一覧　>　PHPとは？
http://localhost:3000/instructor/lesson/edit?course_id=1&chapter_id=1&lesson_id=11
② プレビューボタンを押下する。
③下記（プレビュー画面）が新規タブで作成される
http://localhost:3000/instructor/lesson/preview?courseId=1&chapterId=1&lessonId=1
④挙動確認

## 考慮してほしいこと
特になし
## 確認してほしいこと
とりあえず動くように作成しました。リファクタリングすべき箇所もあると思うので教えてほしい。