### PR TITLE
JKA-513 React ログイン状態で/instructor/loginにアクセスすると強制リダイレクトでトップページへ遷移 ※講師側

### DIFF
--- a/components/organisms/header/InstructorHeader.tsx
+++ b/components/organisms/header/InstructorHeader.tsx
@@ -10,7 +10,7 @@ export const InstructorHeader: FC<Props> = ({ isLogin = true }) => {
   return (
     <Header
       isLogin={isLogin}
-      homeUrl='/instructor/courses'
+      homeUrl="/instructor/courses"
       renderUserDropDown={() => <InstructorUserDropDown />}
     />
   );

--- a/components/organisms/user-dropdown/InstructorUserDropDown.tsx
+++ b/components/organisms/user-dropdown/InstructorUserDropDown.tsx
@@ -4,7 +4,6 @@ import Router from 'next/router';
 import { UserDropDown } from './presentations/UserDropDown';
 import { mutate } from 'swr';
 import Link from 'next/link';
-import { useFetchInstructor } from '@/features/instructor/hooks/useFetchInstructor';
 
 export const InstructorUserDropDown: FC = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/components/organisms/user-dropdown/InstructorUserDropDown.tsx
+++ b/components/organisms/user-dropdown/InstructorUserDropDown.tsx
@@ -4,12 +4,13 @@ import Router from 'next/router';
 import { UserDropDown } from './presentations/UserDropDown';
 import { mutate } from 'swr';
 import Link from 'next/link';
+import { useFetchInstructor } from '@/features/instructor/hooks/useFetchInstructor';
 
 export const InstructorUserDropDown: FC = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const clickHandler = async () => {
-    await mutate(null, false);
+    await mutate('/api/v1/instructor', null, false);
     await Axios.post('/logout/instructor').then((res) => {
       if (res.status === 200) {
         Router.push('/instructor/login');

--- a/features/instructor-students/components/CustomizedLabel.tsx
+++ b/features/instructor-students/components/CustomizedLabel.tsx
@@ -1,23 +1,22 @@
 export const renderCustomizedLabel = (props: {
-    x?: number | string | undefined;
-    y?: number | string | undefined;
-    value?: number | string | undefined;
-  }) => {
-    const chartWidth = 400;
-    const { y, value } = props;
-  
-    const yValue = (() => {
-      if (typeof y === 'undefined') return 0;
-      if (typeof y === 'string') {
-        return parseInt(y);
-      }
-      return y;
-    })();
-  
-    return (
-      <text x={chartWidth - 30} y={yValue + 15} fill="#666" textAnchor="end">
-        {`${value}％`}
-      </text>
-    );
-  };
-  
+  x?: number | string | undefined;
+  y?: number | string | undefined;
+  value?: number | string | undefined;
+}) => {
+  const chartWidth = 400;
+  const { y, value } = props;
+
+  const yValue = (() => {
+    if (typeof y === 'undefined') return 0;
+    if (typeof y === 'string') {
+      return parseInt(y);
+    }
+    return y;
+  })();
+
+  return (
+    <text x={chartWidth - 30} y={yValue + 15} fill="#666" textAnchor="end">
+      {`${value}％`}
+    </text>
+  );
+};

--- a/features/instructor-students/components/StudentAttendanceStatusCard.tsx
+++ b/features/instructor-students/components/StudentAttendanceStatusCard.tsx
@@ -9,7 +9,7 @@ import {
 } from 'recharts';
 import { useFetchAttendanceStatus } from '@/features/attendance/hooks/useFetchAttendanceStatus';
 import { Typography } from '@/components/atoms/Typography';
-import { renderCustomizedLabel } from '../components/CustomizedLabel'
+import { renderCustomizedLabel } from '../components/CustomizedLabel';
 
 interface Props {
   courseId: number | null;
@@ -24,7 +24,6 @@ const studentAttendanceStatus = {
     { title: 'PHPPHPチャプター①', chapter_progress: 30 },
     { title: 'PHPチャプター②', chapter_progress: 100 },
     { title: 'PHPチャプター③', chapter_progress: 100 },
-    
   ],
 };
 
@@ -60,7 +59,7 @@ export const StudentAttendanceStatusCard: React.FC<Props> = ({ courseId }) => {
                 <BarChart
                   layout="vertical"
                   data={data}
-                  margin={{ top: 0, right: 10, left: 60, bottom:10 }}
+                  margin={{ top: 0, right: 10, left: 60, bottom: 10 }}
                 >
                   <XAxis type="number" domain={[0, 100]} hide />
                   <YAxis

--- a/features/instructor-students/components/StudentDetailCard.tsx
+++ b/features/instructor-students/components/StudentDetailCard.tsx
@@ -57,7 +57,13 @@ export const StudentDetailCard: React.FC<Props> = ({ studentId }) => {
           <p>{Student?.purpose}</p>
 
           <p className="font-semibold">性別:</p>
-          <p>{Student?.gender === 'man' ? '男性' : Student?.gender === 'woman' ? '女性' : '性別未設定'}</p>
+          <p>
+            {Student?.gender === 'man'
+              ? '男性'
+              : Student?.gender === 'woman'
+                ? '女性'
+                : '性別未設定'}
+          </p>
 
           <p className="font-semibold">住所:</p>
           <p>{Student?.address}</p>

--- a/features/instructor/hooks/useFetchInstructor.ts
+++ b/features/instructor/hooks/useFetchInstructor.ts
@@ -3,15 +3,19 @@ import useSWR from 'swr';
 import { Instructor } from '../types/Instructor';
 
 export const useFetchInstructor = () => {
-  const { data, isLoading, error, mutate } = useSWR<{
+  const { data, isLoading, isValidating, error, mutate } = useSWR<{
     data: Instructor;
   }>('/api/v1/instructor', fetcher, {
     revalidateOnFocus: false,
+    onErrorRetry: (error) => {
+      if (error.response.status === 401) return;
+    },
   });
 
   return {
     instructor: data?.data,
     isLoading,
+    isValidating,
     error,
     mutate,
   };

--- a/features/login/components/Auth/InstructorAuthWrapper.tsx
+++ b/features/login/components/Auth/InstructorAuthWrapper.tsx
@@ -3,17 +3,24 @@ import useSWR from 'swr';
 import { fetcher } from '@/lib/Fetcher';
 import { Loading } from '@/components/utils/Loading';
 import Router from 'next/router';
+import { useFetchInstructor } from '@/features/instructor/hooks/useFetchInstructor';
 
 type Props = {
   children: ReactNode;
 };
 
 export const InstructorAuthWrapper: FC<Props> = ({ children }) => {
-  const { isValidating, error } = useSWR('/api/v1/instructor', fetcher);
+  const { instructor, isLoading, isValidating, error } = useFetchInstructor();
 
   useEffect(() => {
-    if (!isValidating && error) {
+    if (!isValidating && error && Router.pathname !== '/instructor/login') {
       Router.push('/instructor/login');
+    } else if (
+      Router.pathname === '/instructor/login' &&
+      instructor &&
+      !isLoading
+    ) {
+      Router.push('/instructor/courses');
     }
   }, [isValidating, error]);
 

--- a/features/login/components/Auth/InstructorAuthWrapper.tsx
+++ b/features/login/components/Auth/InstructorAuthWrapper.tsx
@@ -1,6 +1,4 @@
 import { FC, ReactNode, useEffect } from 'react';
-import useSWR from 'swr';
-import { fetcher } from '@/lib/Fetcher';
 import { Loading } from '@/components/utils/Loading';
 import Router from 'next/router';
 import { useFetchInstructor } from '@/features/instructor/hooks/useFetchInstructor';

--- a/features/login/components/Form/InstructorLoginForm.tsx
+++ b/features/login/components/Form/InstructorLoginForm.tsx
@@ -5,6 +5,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Axios } from '@/lib/api';
 import Router from 'next/router';
 import { LoginForm } from './presentations/LoginForm';
+import { mutate } from 'swr';
 
 export const InstructorLoginForm: FC = () => {
   const [isUnauthorized, setIsUnauthorized] = useState<boolean>(false);
@@ -33,6 +34,7 @@ export const InstructorLoginForm: FC = () => {
           isSending.current = false;
           setValue('password', '');
           if (res.data.result === true) {
+            mutate('/api/v1/instructor');
             Router.push('/instructor/courses');
           }
         })

--- a/features/login/components/Form/InstructorLoginForm.tsx
+++ b/features/login/components/Form/InstructorLoginForm.tsx
@@ -22,7 +22,7 @@ export const InstructorLoginForm: FC = () => {
     formState: { errors },
   } = useForm({
     mode: 'onSubmit',
-    // resolver: yupResolver(LoginFormSchema),
+    resolver: yupResolver(LoginFormSchema),
     defaultValues,
   });
 

--- a/pages/instructor/login/index.tsx
+++ b/pages/instructor/login/index.tsx
@@ -1,12 +1,15 @@
 import { InstructorLayout } from '@/components/organisms/header';
 import { InstructorLoginForm } from '@/features/login/components/Form/InstructorLoginForm';
 import { NextPage } from 'next';
+import { InstructorAuthWrapper } from '@/features/login/components/Auth';
 
 const Index: NextPage = () => {
   return (
-    <InstructorLayout isLogin={false}>
-      <InstructorLoginForm />
-    </InstructorLayout>
+    <InstructorAuthWrapper>
+      <InstructorLayout isLogin={false}>
+        <InstructorLoginForm />
+      </InstructorLayout>
+    </InstructorAuthWrapper>
   );
 };
 


### PR DESCRIPTION
## task
- JKA-513 

## 概要
- React ログイン状態で/instructor/loginにアクセスすると強制リダイレクトでトップページへ遷移 ※講師側

## 動作確認手順
- 講師側でログアウト済み
  - ログイン後の画面（/instructor/courses等）に遷移すると、/instructor/login画面に戻る
- 講師側でログインする
  - /instructor/coursesに遷移する
- 講師側でログイン済み
  - /instructor/login画面に遷移すると、/instructor/coursesに遷移する
- 講師側でログイン済み
  - ログアウトすると、/instructor/login画面に遷移する
  
## 確認してほしいこと
- InstructorLoginForm.tsx
  - mutate('/api/v1/instructor');がないとトップページへ遷移できないのですが、その理屈がわからないです。可能であればお手隙で教えていただきたいです。
