### PR TITLE
JKA-1593 React ログインフォームの改善（ちゃこ）

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { LoginFormUI } from './LoginForm.ui';
 import { Axios } from '@/lib/api';
+import axios from 'axios';
 
 const loginSchema = z.object({
   email: z
@@ -33,13 +34,16 @@ export function LoginForm() {
     return Axios.get('/sanctum/csrf-cookie').then(() => {
       return Axios.post('/login', data)
         .then(() => {})
-        .catch((error: Error) => {
-          console.log('Login error:', error);
-          form.resetField('password');
-          form.setError('password', {
-            type: 'server',
-            message: 'メールアドレスまたはパスワードが正しくありません',
-          });
+        .catch((error: unknown) => {
+          if (axios.isAxiosError(error)) {
+            if (error.response?.status === 401) {
+              form.resetField('password');
+              form.setError('password', {
+                type: 'server',
+                message: 'メールアドレスまたはパスワードが正しくありません',
+              });
+            }
+          }  
           return;
         });
     });

--- a/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
+import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { LoginFormUI } from './LoginForm.ui';
@@ -19,6 +20,7 @@ const loginSchema = z.object({
 export type LoginFormValues = z.infer<typeof loginSchema>;
 
 export function LoginForm() {
+  const [showPassword, setShowPassword] = useState(false);
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
     defaultValues: {
@@ -28,14 +30,27 @@ export function LoginForm() {
   });
 
   const handleSubmit = form.handleSubmit(async (data: LoginFormValues) => {
-    Axios.get('/sanctum/csrf-cookie').then(() => {
-      Axios.post('/login', data)
+    return Axios.get('/sanctum/csrf-cookie').then(() => {
+      return Axios.post('/login', data)
         .then(() => {})
         .catch((error: Error) => {
-          console.error('Login error:', error);
+          console.log('Login error:', error);
+          form.resetField('password');
+          form.setError('password', {
+            type: 'server',
+            message: 'メールアドレスまたはパスワードが正しくありません',
+          });
+          return;
         });
     });
   });
 
-  return <LoginFormUI form={form} onSubmit={handleSubmit} />;
+  return (
+    <LoginFormUI
+      form={form}
+      onSubmit={handleSubmit}
+      showPassword={showPassword}
+      onTogglePassword={() => setShowPassword((prev) => !prev)}
+    />
+  );
 }

--- a/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -9,9 +9,7 @@ import { Axios } from '@/lib/api';
 import axios from 'axios';
 
 const loginSchema = z.object({
-  email: z
-    .email('有効なメールアドレスを入力してください')
-    .min(1, 'メールアドレスを入力してください'),
+  email: z.email('有効なメールアドレスを入力してください'),
   password: z
     .string()
     .min(1, 'パスワードを入力してください')
@@ -43,7 +41,7 @@ export function LoginForm() {
                 message: 'メールアドレスまたはパスワードが正しくありません',
               });
             }
-          }  
+          }
           return;
         });
     });

--- a/src/features/auth/components/LoginForm/LoginForm.ui.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.ui.tsx
@@ -23,12 +23,11 @@ type LoginFormUIProps = {
 };
 
 export function LoginFormUI({
-    form,
-    onSubmit,
-    showPassword,
-    onTogglePassword,
-  }: LoginFormUIProps) 
-{
+  form,
+  onSubmit,
+  showPassword,
+  onTogglePassword,
+}: LoginFormUIProps) {
   const { register } = form;
   const { errors } = useFormState({ control: form.control });
 

--- a/src/features/auth/components/LoginForm/LoginForm.ui.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.ui.tsx
@@ -13,6 +13,7 @@ import {
   CardFooter,
 } from '@/components/atoms/Card';
 import { LoginFormValues } from './LoginForm';
+import { Eye, EyeOff } from 'lucide-react';
 
 type LoginFormUIProps = {
   form: UseFormReturn<LoginFormValues>;
@@ -64,14 +65,24 @@ export function LoginFormUI({
                 aria-invalid={!!errors.password}
                 className="pr-10"
               />
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="icon"
                 onClick={onTogglePassword}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-sm"
-                aria-label={showPassword ? 'パスワードを非表示にする' : 'パスワードを表示する'}
+                aria-label={
+                  showPassword
+                    ? 'パスワードを非表示にする'
+                    : 'パスワードを表示する'
+                }
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-0 bg-transparent hover:bg-transparent focus:ring-0"
               >
-                {showPassword ? '🚫👁️' : '👁️'}
-              </button>
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </Button>
             </div>
             {errors.password && (
               <p className="text-sm text-destructive">

--- a/src/features/auth/components/LoginForm/LoginForm.ui.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.ui.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { UseFormReturn } from 'react-hook-form';
+import { UseFormReturn, useFormState } from 'react-hook-form';
 import { Button } from '@/components/atoms/Button';
 import { Input } from '@/components/atoms/Input';
 import { Label } from '@/components/atoms/Label';
@@ -17,13 +17,19 @@ import { LoginFormValues } from './LoginForm';
 type LoginFormUIProps = {
   form: UseFormReturn<LoginFormValues>;
   onSubmit: (e: React.FormEvent) => void;
+  showPassword: boolean;
+  onTogglePassword: () => void;
 };
 
-export function LoginFormUI({ form, onSubmit }: LoginFormUIProps) {
-  const {
-    register,
-    formState: { errors },
-  } = form;
+export function LoginFormUI({
+    form,
+    onSubmit,
+    showPassword,
+    onTogglePassword,
+  }: LoginFormUIProps) 
+{
+  const { register } = form;
+  const { errors } = useFormState({ control: form.control });
 
   return (
     <Card className="w-full max-w-md">
@@ -50,12 +56,23 @@ export function LoginFormUI({ form, onSubmit }: LoginFormUIProps) {
           </div>
           <div className="space-y-2">
             <Label htmlFor="password">パスワード</Label>
-            <Input
-              id="password"
-              type="password"
-              {...register('password')}
-              aria-invalid={!!errors.password}
-            />
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                {...register('password')}
+                aria-invalid={!!errors.password}
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={onTogglePassword}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-sm"
+                aria-label={showPassword ? 'パスワードを非表示にする' : 'パスワードを表示する'}
+              >
+                {showPassword ? '🚫👁️' : '👁️'}
+              </button>
+            </div>
             {errors.password && (
               <p className="text-sm text-destructive">
                 {errors.password.message}


### PR DESCRIPTION
# Jira
JKA-1593


# 概要
ログインフォームのUX向上対応を行いました。  
パスワード表示切り替え、送信後のパスワードリセット、ログイン失敗時のエラーメッセージ表示を実装しています。
動作確認済みです。


# 対応内容
- パスワードの表示／非表示を切り替えられるボタンを追加
- ログイン失敗時にユーザー向けエラーメッセージを表示
- ログインリクエスト送信後、パスワード入力欄をリセット
- react-hook-form の `setError` を利用したエラーハンドリング対応


# 動作確認手順

1. ログイン画面にアクセス
2. 誤ったメールアドレスもしくはパスワードを入力
3. パスワード表示／非表示の切り替えが正しく動作することを確認
4. ログインボタンを押し、「メールアドレスまたはパスワードが正しくありません」と表示されることを確認
5. エラー表示後、パスワード入力欄がクリアされることを確認


# 考慮して欲しいこと
- フォームの再レンダリング制御のため、`useFormState` を使用しています
- 既存のバリデーションエラー表示の仕様に合わせた実装としたつもりです。
- メールアドレス入力値は保持し、パスワードのみリセットする挙動としています


# 確認して欲しいこと
- ログイン失敗時のエラーメッセージ表示タイミング
- パスワード表示切り替えのUXに問題がないか
- 送信後にパスワードが正しくリセットされているか
