### PR TITLE
JKA-1597 React Header.ui.tsxを共通コンポーネント化（ちゃこ）

### DIFF
--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,5 +1,10 @@
 import { HeaderUI } from './Header.ui';
+import { UserDropDown } from '@/features/user/components/UserDropDown';
 
 export function Header() {
-  return <HeaderUI />;
+  return (
+    <HeaderUI>
+      <UserDropDown />
+    </HeaderUI>
+  );
 }

--- a/src/components/organisms/Header/Header.ui.tsx
+++ b/src/components/organisms/Header/Header.ui.tsx
@@ -1,11 +1,15 @@
-import { UserDropDown } from '@/features/user/components/UserDropDown';
+import React from 'react';
 
-export function HeaderUI() {
+type HeaderUIProps = {
+  children?: React.ReactNode;
+};
+
+export function HeaderUI({ children }: HeaderUIProps) {
   return (
     <header className="border-b bg-primary">
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
         <h1 className="text-xl font-bold text-[#FBF459]">受講管理アプリ</h1>
-        <UserDropDown />
+        {children}
       </div>
     </header>
   );


### PR DESCRIPTION
## Jira
JKA-1597

## 概要
ヘッダーをゲスト用・講師用・生徒用に分割するための準備として、
HeaderUI を共通ベースコンポーネント化しました。

HeaderUI では右側コンテンツを children 経由で受け取る構成とし、
「誰用のヘッダーか」を呼び出し側で制御できるようにしています。

## 対応内容
- HeaderUI を共通レイアウト専用コンポーネントとして修正
- 右側コンテンツを children props で受け取れるよう変更
- HeaderUI から UserDropDown の直接依存を削除
- Header.tsx 側で UserDropDown を children として渡す構成に変更

## 動作確認手順
- 生徒画面でヘッダーが表示されていることを確認
- ヘッダー右側に UserDropDown が表示されていることを確認
- ドロップダウンを開閉できることを確認
- 「ログアウト」をクリックし、ブラウザの console に `logout` が出力されることを確認

## 考慮事項
- 本対応は「ヘッダー3種類分割」計画の一部であり、表示内容の切り替えは今後のタスクで対応予定
- HeaderUI は見た目のみを責務とし、表示内容の制御は Header.tsx 側に委譲しています

## 確認してほしいこと
- HeaderUI の共通化方針に問題がないか
- 今後のゲスト用／講師用ヘッダー分割に繋げやすい構成になっているか
