### PR TITLE
JKA-1600 React InstructorHeaderコンポーネントの作成（ちゃこ）

### DIFF
--- a/src/components/organisms/Header/InstructorHeader.tsx
+++ b/src/components/organisms/Header/InstructorHeader.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { InstructorHeaderUI } from './InstructorHeader.ui';
+
+export function InstructorHeader() {
+  const handleLogout = () => {
+    // 講師用ログアウト処理
+    console.log('instructor logout');
+  };
+
+  return <InstructorHeaderUI userName="山田 花子" onLogout={handleLogout} />;
+}

--- a/src/components/organisms/Header/InstructorHeader.tsx
+++ b/src/components/organisms/Header/InstructorHeader.tsx
@@ -4,7 +4,7 @@ import { InstructorHeaderUI } from './InstructorHeader.ui';
 
 export function InstructorHeader() {
   const handleLogout = () => {
-    // 講師用ログアウト処理
+    // TODO: 講師用ログアウトエンドポイントを設定
     console.log('instructor logout');
   };
 

--- a/src/components/organisms/Header/InstructorHeader.ui.tsx
+++ b/src/components/organisms/Header/InstructorHeader.ui.tsx
@@ -15,7 +15,10 @@ type InstructorHeaderUIProps = {
   onLogout: () => void;
 };
 
-export function InstructorHeaderUI({ userName, onLogout }: InstructorHeaderUIProps) {
+export function InstructorHeaderUI({
+  userName,
+  onLogout,
+}: InstructorHeaderUIProps) {
   return (
     <HeaderUI>
       <DropdownMenu>
@@ -24,6 +27,7 @@ export function InstructorHeaderUI({ userName, onLogout }: InstructorHeaderUIPro
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem asChild>
+            {/* TODO: 講師用ユーザー情報編集URL */}
             <Link href="#">ユーザー情報編集</Link>
           </DropdownMenuItem>
           <DropdownMenuItem onClick={onLogout}>ログアウト</DropdownMenuItem>

--- a/src/components/organisms/Header/InstructorHeader.ui.tsx
+++ b/src/components/organisms/Header/InstructorHeader.ui.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Link from 'next/link';
+import { Button } from '@/components/atoms/Button';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/atoms/DropdownMenu';
+import { HeaderUI } from './Header.ui';
+
+type InstructorHeaderUIProps = {
+  userName: string;
+  onLogout: () => void;
+};
+
+export function InstructorHeaderUI({ userName, onLogout }: InstructorHeaderUIProps) {
+  return (
+    <HeaderUI>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="secondary">{userName}</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild>
+            <Link href="#">ユーザー情報編集</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onLogout}>ログアウト</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </HeaderUI>
+  );
+}


### PR DESCRIPTION
## Jira
JKA-1600

## 概要
講師用のヘッダーコンポーネントとして、  
`InstructorHeader` を新規に作成しました。

前タスクで共通化した `HeaderUI` をベースに、  
既存の `UserDropDown` と同等の機能を  
Container / Presentational パターンで実装しています。
講師用ヘッダーを独立したコンポーネントとして切り出しました。

## 対応内容
- 講師用ヘッダーの Container コンポーネント `InstructorHeader.tsx` を新規作成
- 表示専用の Presentational コンポーネント `InstructorHeader.ui.tsx` を新規作成
- `HeaderUI` を利用し、ヘッダー全体のレイアウトは共通化
- ドロップダウンメニューに以下の項目を表示
  - ユーザー情報編集
  - ログアウト
- 既存の `UserDropDown` と同等のUI・操作感を維持
- `InstructorHeader` は Client Component のため、  
  `HeaderUI` を Client Component として扱えるよう調整

## 動作確認手順
- 講師画面で既存の `Header` がこれまで通り表示されていることを確認
- ヘッダー右側にユーザー名ボタンが表示されていることを確認
- ボタンをクリックするとドロップダウンが表示されることを確認
- 「ユーザー情報編集」「ログアウト」が表示されることを確認
- 「ログアウト」をクリックすると console に `instructor logout` が出力されることを確認

## 考慮事項
- 本対応は「ヘッダーを役割別に分割する」計画の一部です
- 本PRでは講師用ヘッダーの作成までとし、  
  実際の画面での切り替え（認証状態による出し分け）は今後のタスクで対応予定です
- 既存のヘッダー動作確認が行えるよう、  
  `Header.tsx` は従来どおり `UserDropDown` を表示する構成としています
- `HeaderUI` はレイアウト専用とし、  
  表示内容の差分は各ヘッダーコンポーネント側で制御する方針です

## 確認してほしいこと
- Container / Presentational パターンの分離が適切か
- 既存の `UserDropDown` と同等の機能を満たせているか
