### PR TITLE
JKA-1606 React お知らせ一覧ページの実装（生徒側）（ちゃこ）

### DIFF
--- a/src/app/(student)/attendance/page.tsx
+++ b/src/app/(student)/attendance/page.tsx
@@ -17,7 +17,7 @@ export default function AttendancePage() {
           <h1 className="text-lg font-semibold">講座一覧</h1>
           <CourseSearchBox />
         </div>
-        <div className="h-px w-full bg-border" />
+        <hr className="border-border" />
       </div>
 
       {/* 操作エリア */}

--- a/src/app/(student)/notifications/page.tsx
+++ b/src/app/(student)/notifications/page.tsx
@@ -1,4 +1,4 @@
-import { NotificationList } from "@/features/notification/components/NotificationList/NotificationList";
+import { NotificationList } from '@/features/notification/components/NotificationList/NotificationList';
 
 export default function NotificationsPage() {
   return (
@@ -8,7 +8,7 @@ export default function NotificationsPage() {
         <h1 className="text-lg font-semibold">お知らせ一覧</h1>
 
         {/* グレーの区切り線 */}
-        <div className="h-px w-full bg-border" />
+        <hr className="border-border" />
       </div>
 
       {/* お知らせ一覧 */}
@@ -16,4 +16,3 @@ export default function NotificationsPage() {
     </div>
   );
 }
-

--- a/src/app/(student)/notifications/page.tsx
+++ b/src/app/(student)/notifications/page.tsx
@@ -1,0 +1,19 @@
+import { NotificationList } from "@/features/notification/components/NotificationList/NotificationList";
+
+export default function NotificationsPage() {
+  return (
+    <div className="px-6 py-4">
+      {/* ページ内ヘッダー（attendance と同じ構造） */}
+      <div className="mx-auto space-y-4">
+        <h1 className="text-lg font-semibold">お知らせ一覧</h1>
+
+        {/* グレーの区切り線 */}
+        <div className="h-px w-full bg-border" />
+      </div>
+
+      {/* お知らせ一覧 */}
+      <NotificationList />
+    </div>
+  );
+}
+

--- a/src/components/atoms/Table.tsx
+++ b/src/components/atoms/Table.tsx
@@ -1,0 +1,9 @@
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"

--- a/src/components/atoms/Table.tsx
+++ b/src/components/atoms/Table.tsx
@@ -6,4 +6,4 @@ export {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table"
+} from '@/components/ui/table';

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/features/notification/components/NotificationList/NotificationList.tsx
+++ b/src/features/notification/components/NotificationList/NotificationList.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { NotificationListUI } from "./NotificationList.ui";
+import { Notification } from "../NotificationTable/NotificationTable.ui";
+
+const PAGE_SIZE = 5;
+
+const mockNotifications: Notification[] = [
+  {
+    id: "1",
+    title: "領収書について",
+    courseName: "PHPコース",
+    courseDeadline: null,
+    startDate: "2023/9/25",
+  },
+  {
+    id: "2",
+    title: "レッスンについて",
+    courseName: "Javaコース",
+    courseDeadline: "2024/12/31",
+    startDate: "2024/1/1",
+  },
+  {
+    id: "3",
+    title: "課題提出について",
+    courseName: "Reactコース",
+    courseDeadline: "2024/6/30",
+    startDate: "2024/2/15",
+  },
+  {
+    id: "4",
+    title: "メンテナンスのお知らせ",
+    courseName: "共通",
+    courseDeadline: null,
+    startDate: "2024/3/10",
+  },
+  {
+    id: "5",
+    title: "修了証発行について",
+    courseName: "PHPコース",
+    courseDeadline: null,
+    startDate: "2024/3/20",
+  },
+  {
+    id: "6",
+    title: "追加教材のお知らせ",
+    courseName: "Javaコース",
+    courseDeadline: null,
+    startDate: "2024/4/1",
+  },
+];
+
+export function NotificationList() {
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const sortedNotifications = useMemo(() => {
+    return [...mockNotifications].sort((a, b) => {
+      const aDate = new Date(a.startDate).getTime();
+      const bDate = new Date(b.startDate).getTime();
+      return sortOrder === "asc" ? aDate - bDate : bDate - aDate;
+    });
+  }, [sortOrder]);
+
+  const totalPages = Math.ceil(sortedNotifications.length / PAGE_SIZE);
+
+  const paginatedNotifications = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE;
+    const end = start + PAGE_SIZE;
+    return sortedNotifications.slice(start, end);
+  }, [sortedNotifications, currentPage]);
+
+  const handleSortChange = () => {
+    setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+    setCurrentPage(1);
+  };
+
+  return (
+    <NotificationListUI
+      notifications={paginatedNotifications}
+      sortOrder={sortOrder}
+      onSortChange={handleSortChange}
+      currentPage={currentPage}
+      totalPages={totalPages}
+      onPageChange={setCurrentPage}
+    />
+  );
+}

--- a/src/features/notification/components/NotificationList/NotificationList.tsx
+++ b/src/features/notification/components/NotificationList/NotificationList.tsx
@@ -1,65 +1,65 @@
-"use client";
+'use client';
 
-import { useMemo, useState } from "react";
-import { NotificationListUI } from "./NotificationList.ui";
-import { Notification } from "../NotificationTable/NotificationTable.ui";
+import { useMemo, useState } from 'react';
+import { NotificationListUI } from './NotificationList.ui';
+import { Notification } from '../NotificationTable/NotificationTable.ui';
 
 const PAGE_SIZE = 5;
 
 const mockNotifications: Notification[] = [
   {
-    id: "1",
-    title: "領収書について",
-    courseName: "PHPコース",
+    id: '1',
+    title: '領収書について',
+    courseName: 'PHPコース',
     courseDeadline: null,
-    startDate: "2023/9/25",
+    startDate: '2023/9/25',
   },
   {
-    id: "2",
-    title: "レッスンについて",
-    courseName: "Javaコース",
-    courseDeadline: "2024/12/31",
-    startDate: "2024/1/1",
+    id: '2',
+    title: 'レッスンについて',
+    courseName: 'Javaコース',
+    courseDeadline: '2024/12/31',
+    startDate: '2024/1/1',
   },
   {
-    id: "3",
-    title: "課題提出について",
-    courseName: "Reactコース",
-    courseDeadline: "2024/6/30",
-    startDate: "2024/2/15",
+    id: '3',
+    title: '課題提出について',
+    courseName: 'Reactコース',
+    courseDeadline: '2024/6/30',
+    startDate: '2024/2/15',
   },
   {
-    id: "4",
-    title: "メンテナンスのお知らせ",
-    courseName: "共通",
+    id: '4',
+    title: 'メンテナンスのお知らせ',
+    courseName: '共通',
     courseDeadline: null,
-    startDate: "2024/3/10",
+    startDate: '2024/3/10',
   },
   {
-    id: "5",
-    title: "修了証発行について",
-    courseName: "PHPコース",
+    id: '5',
+    title: '修了証発行について',
+    courseName: 'PHPコース',
     courseDeadline: null,
-    startDate: "2024/3/20",
+    startDate: '2024/3/20',
   },
   {
-    id: "6",
-    title: "追加教材のお知らせ",
-    courseName: "Javaコース",
+    id: '6',
+    title: '追加教材のお知らせ',
+    courseName: 'Javaコース',
     courseDeadline: null,
-    startDate: "2024/4/1",
+    startDate: '2024/4/1',
   },
 ];
 
 export function NotificationList() {
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [currentPage, setCurrentPage] = useState(1);
 
   const sortedNotifications = useMemo(() => {
     return [...mockNotifications].sort((a, b) => {
       const aDate = new Date(a.startDate).getTime();
       const bDate = new Date(b.startDate).getTime();
-      return sortOrder === "asc" ? aDate - bDate : bDate - aDate;
+      return sortOrder === 'asc' ? aDate - bDate : bDate - aDate;
     });
   }, [sortOrder]);
 
@@ -72,7 +72,7 @@ export function NotificationList() {
   }, [sortedNotifications, currentPage]);
 
   const handleSortChange = () => {
-    setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+    setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
     setCurrentPage(1);
   };
 

--- a/src/features/notification/components/NotificationList/NotificationList.ui.tsx
+++ b/src/features/notification/components/NotificationList/NotificationList.ui.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { NotificationTable } from "../NotificationTable/NotificationTable";
+import { Notification } from "../NotificationTable/NotificationTable.ui";
+import { Button } from "@/components/atoms/Button";
+
+type Props = {
+  notifications: Notification[];
+  sortOrder: "asc" | "desc";
+  onSortChange: () => void;
+
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+};
+
+export function NotificationListUI({
+  notifications,
+  sortOrder,
+  onSortChange,
+  currentPage,
+  totalPages,
+  onPageChange,
+}: Props) {
+  return (
+    <div className="space-y-6">
+      <NotificationTable
+        notifications={notifications}
+        sortOrder={sortOrder}
+        onSortChange={onSortChange}
+      />
+
+      {/* ページネーション */}
+      <div className="flex items-center justify-center gap-2">
+        {/* 前へ */}
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={currentPage === 1}
+          onClick={() => onPageChange(currentPage - 1)}
+        >
+          &lt;
+        </Button>
+
+        {/* ページ番号 */}
+        {Array.from({ length: totalPages }).map((_, index) => {
+          const page = index + 1;
+          const isActive = page === currentPage;
+
+          return (
+            <Button
+              key={page}
+              variant={isActive ? "default" : "outline"}
+              size="sm"
+              onClick={() => onPageChange(page)}
+            >
+              {page}
+            </Button>
+          );
+        })}
+
+        {/* 次へ */}
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={currentPage === totalPages}
+          onClick={() => onPageChange(currentPage + 1)}
+        >
+          &gt;
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/notification/components/NotificationList/NotificationList.ui.tsx
+++ b/src/features/notification/components/NotificationList/NotificationList.ui.tsx
@@ -1,12 +1,12 @@
-"use client";
+'use client';
 
-import { NotificationTable } from "../NotificationTable/NotificationTable";
-import { Notification } from "../NotificationTable/NotificationTable.ui";
-import { Button } from "@/components/atoms/Button";
+import { NotificationTable } from '../NotificationTable/NotificationTable';
+import { Notification } from '../NotificationTable/NotificationTable.ui';
+import { Button } from '@/components/atoms/Button';
 
 type Props = {
   notifications: Notification[];
-  sortOrder: "asc" | "desc";
+  sortOrder: 'asc' | 'desc';
   onSortChange: () => void;
 
   currentPage: number;
@@ -50,7 +50,7 @@ export function NotificationListUI({
           return (
             <Button
               key={page}
-              variant={isActive ? "default" : "outline"}
+              variant={isActive ? 'default' : 'outline'}
               size="sm"
               onClick={() => onPageChange(page)}
             >

--- a/src/features/notification/components/NotificationTable/NotificationTable.tsx
+++ b/src/features/notification/components/NotificationTable/NotificationTable.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { NotificationTableUI, Notification } from "./NotificationTable.ui";
+
+type Props = {
+  notifications: Notification[];
+  sortOrder: "asc" | "desc";
+  onSortChange: () => void;
+};
+
+export function NotificationTable(props: Props) {
+  return <NotificationTableUI {...props} />;
+}

--- a/src/features/notification/components/NotificationTable/NotificationTable.tsx
+++ b/src/features/notification/components/NotificationTable/NotificationTable.tsx
@@ -1,10 +1,10 @@
-"use client";
+'use client';
 
-import { NotificationTableUI, Notification } from "./NotificationTable.ui";
+import { NotificationTableUI, Notification } from './NotificationTable.ui';
 
 type Props = {
   notifications: Notification[];
-  sortOrder: "asc" | "desc";
+  sortOrder: 'asc' | 'desc';
   onSortChange: () => void;
 };
 

--- a/src/features/notification/components/NotificationTable/NotificationTable.ui.tsx
+++ b/src/features/notification/components/NotificationTable/NotificationTable.ui.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/atoms/Table";
+import { Button } from "@/components/atoms/Button";
+import { ChevronUp, ChevronDown } from "lucide-react";
+
+export type Notification = {
+  id: string;
+  title: string;
+  courseName: string;
+  courseDeadline: string | null;
+  startDate: string;
+};
+
+type Props = {
+  notifications: Notification[];
+  sortOrder: "asc" | "desc";
+  onSortChange: () => void;
+};
+
+export function NotificationTableUI({
+  notifications,
+  sortOrder,
+  onSortChange,
+}: Props) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>
+            <span className="inline-flex items-center gap-1">
+              タイトル
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onSortChange}
+                aria-label="タイトルで並び替え"
+                className="text-muted-foreground"
+              >
+                {sortOrder === "asc" ? <ChevronUp /> : <ChevronDown />}
+              </Button>
+            </span>
+          </TableHead>
+
+          <TableHead>
+            <span className="inline-flex items-center gap-1">
+              講座名
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onSortChange}
+                aria-label="講座名で並び替え"
+                className="text-muted-foreground"
+              >
+                {sortOrder === "asc" ? <ChevronUp /> : <ChevronDown />}
+              </Button>
+            </span>
+          </TableHead>
+
+          <TableHead>
+            <span className="inline-flex items-center gap-1">
+              講座受講期限
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onSortChange}
+                aria-label="講座受講期限で並び替え"
+                className="text-muted-foreground"
+              >
+                {sortOrder === "asc" ? <ChevronUp /> : <ChevronDown />}
+              </Button>
+            </span>
+          </TableHead>
+
+          <TableHead>
+            <span className="inline-flex items-center gap-1">
+              開始日付
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onSortChange}
+                aria-label="開始日付で並び替え"
+                className="text-muted-foreground"
+              >
+                {sortOrder === "asc" ? <ChevronUp /> : <ChevronDown />}
+              </Button>
+            </span>
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        {notifications.map((notification) => (
+          <TableRow key={notification.id}>
+            <TableCell className="font-medium">
+              {notification.title}
+            </TableCell>
+            <TableCell>{notification.courseName}</TableCell>
+            <TableCell>
+              {notification.courseDeadline ?? "—"}
+            </TableCell>
+            <TableCell>{notification.startDate}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/features/notification/components/NotificationTable/NotificationTable.ui.tsx
+++ b/src/features/notification/components/NotificationTable/NotificationTable.ui.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import {
   Table,
@@ -7,9 +7,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/atoms/Table";
-import { Button } from "@/components/atoms/Button";
-import { ChevronUp, ChevronDown } from "lucide-react";
+} from '@/components/atoms/Table';
+import { Button } from '@/components/atoms/Button';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 
 export type Notification = {
   id: string;
@@ -21,7 +21,7 @@ export type Notification = {
 
 type Props = {
   notifications: Notification[];
-  sortOrder: "asc" | "desc";
+  sortOrder: 'asc' | 'desc';
   onSortChange: () => void;
 };
 
@@ -44,7 +44,7 @@ export function NotificationTableUI({
                 aria-label="タイトルで並び替え"
                 className="text-muted-foreground"
               >
-                {sortOrder === "asc" ? <ChevronUp /> : <ChevronDown />}
+                {sortOrder === 'asc' ? <ChevronUp /> : <ChevronDown />}
               </Button>
             </span>
           </TableHead>
@@ -59,7 +59,7 @@ export function NotificationTableUI({
                 aria-label="講座名で並び替え"
                 className="text-muted-foreground"
               >
-                {sortOrder === "asc" ? <ChevronUp /> : <ChevronDown />}
+                {sortOrder === 'asc' ? <ChevronUp /> : <ChevronDown />}
               </Button>
             </span>
           </TableHead>
@@ -74,7 +74,7 @@ export function NotificationTableUI({
                 aria-label="講座受講期限で並び替え"
                 className="text-muted-foreground"
               >
-                {sortOrder === "asc" ? <ChevronUp /> : <ChevronDown />}
+                {sortOrder === 'asc' ? <ChevronUp /> : <ChevronDown />}
               </Button>
             </span>
           </TableHead>
@@ -89,7 +89,7 @@ export function NotificationTableUI({
                 aria-label="開始日付で並び替え"
                 className="text-muted-foreground"
               >
-                {sortOrder === "asc" ? <ChevronUp /> : <ChevronDown />}
+                {sortOrder === 'asc' ? <ChevronUp /> : <ChevronDown />}
               </Button>
             </span>
           </TableHead>
@@ -99,13 +99,9 @@ export function NotificationTableUI({
       <TableBody>
         {notifications.map((notification) => (
           <TableRow key={notification.id}>
-            <TableCell className="font-medium">
-              {notification.title}
-            </TableCell>
+            <TableCell className="font-medium">{notification.title}</TableCell>
             <TableCell>{notification.courseName}</TableCell>
-            <TableCell>
-              {notification.courseDeadline ?? "—"}
-            </TableCell>
+            <TableCell>{notification.courseDeadline ?? '—'}</TableCell>
             <TableCell>{notification.startDate}</TableCell>
           </TableRow>
         ))}


### PR DESCRIPTION
## Jira
JKA-1606

## 概要
生徒向けのお知らせ一覧ページ（/notifications）を新規実装しました。

お知らせ一覧をテーブル形式で表示し、
開始日付による昇順／降順ソート機能も追加しています。

各コンポーネントは Container / Presentational パターンで実装しており、
今後の API 連携や表示ロジック拡張を見据えた構成としています。


## 実装内容
- 生徒向けお知らせ一覧ページ（/notifications）の新規作成
- お知らせ一覧テーブルの実装
- 開始日付による昇順／降順ソート機能の追加
- ページネーション（前へ／次へ／ページ番号）の実装
- shadcn/ui の Table を atoms 経由で利用
- Container / Presentational パターンによる責務分離

## 動作確認手順
1. /notifications にアクセスする
2. お知らせ一覧ページが表示されることを確認
3. お知らせがテーブル形式で表示されることを確認
4. 開始日付のソート切り替えが動作することを確認
5. ページネーション操作でページが切り替わることを確認

## 考慮事項
- 本PRでは API 連携は行っておらず、仮データでの表示のみを行っています
- 各コンポーネントは Container / Presentational 分離を前提とし、
  今後のデータ取得・ソート条件追加・ページネーション拡張を想定した構成としています
- デザインは現行の指示および既存ページ（attendance）に合わせて調整しています

## 確認してほしいこと
- お知らせ一覧ページ全体の構成・責務分離が適切か
- テーブル表示およびソート・ページネーションの実装が要件を満たしているか
- UI レイアウトや操作感に違和感がないか
