### PR TITLE
JKA-1612 React 講座カリキュラム一覧の実装（受講生側）のドラッグ&ドロップの実装(ちゃこ)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,16 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
-    "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-radio-group": "^1.3.8",
+    "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,24 +253,36 @@ packages:
       }
 
   '@dnd-kit/accessibility@3.1.1':
-    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    resolution:
+      {
+        integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==,
+      }
     peerDependencies:
       react: '>=16.8.0'
 
   '@dnd-kit/core@6.3.1':
-    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    resolution:
+      {
+        integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==,
+      }
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
   '@dnd-kit/sortable@10.0.0':
-    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    resolution:
+      {
+        integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==,
+      }
     peerDependencies:
       '@dnd-kit/core': ^6.3.0
       react: '>=16.8.0'
 
   '@dnd-kit/utilities@3.2.2':
-    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    resolution:
+      {
+        integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==,
+      }
     peerDependencies:
       react: '>=16.8.0'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.1)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.68.0(react@19.2.1))
@@ -190,6 +199,28 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -2720,6 +2751,31 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
 
   '@emnapi/core@1.7.1':
     dependencies:

--- a/src/app/(student)/attendance/[attendanceId]/page.tsx
+++ b/src/app/(student)/attendance/[attendanceId]/page.tsx
@@ -1,7 +1,21 @@
 'use client';
 
+import {
+  useState,
+  useCallback
+} from 'react';
 import { CourseSidebar } from '@/features/attendance/components/CourseSidebar/CourseSidebar';
 import { ChapterAccordion } from '@/features/attendance/components/ChapterAccordion/ChapterAccordion';
+import { 
+  DndContext,
+  closestCenter,
+} from '@dnd-kit/core';
+import type { DragEndEvent } from '@dnd-kit/core';
+import { 
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import {
   SidebarInset,
   SidebarProvider,
@@ -9,7 +23,23 @@ import {
 } from '@/components/atoms/Sidebar';
 
 export default function Page() {
-  const chapters = [
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    setChapters((prevChapters) => {
+      const oldIndex = prevChapters.findIndex(
+        (chapter) => chapter.id === active.id
+      );
+      const newIndex = prevChapters.findIndex(
+        (chapter) => chapter.id === over.id
+      );
+
+      return arrayMove(prevChapters, oldIndex, newIndex);
+    });
+  }, []);
+
+  const [chapters, setChapters] = useState([
     {
       id: 'chapter-1',
       title: '第1章 はじめに',
@@ -25,7 +55,7 @@ export default function Page() {
         { id: 'lesson-3', title: 'レッスン3', isCompleted: false },
       ],
     },
-  ];
+  ]);
   return (
     <SidebarProvider>
       <CourseSidebar />
@@ -55,12 +85,22 @@ export default function Page() {
           </div>
 
           {/* カリキュラム一覧 */}
-          {chapters.map((chapter) => (
-            <ChapterAccordion
-              key={chapter.id}
-              chapter={chapter}
-            />
-          ))}
+          <DndContext
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext 
+              items={chapters.map(ch => ch.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {chapters.map((chapter) => (
+                <ChapterAccordion
+                  key={chapter.id}
+                  chapter={chapter}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
         </main>
       </SidebarInset>
     </SidebarProvider>

--- a/src/app/(student)/attendance/[attendanceId]/page.tsx
+++ b/src/app/(student)/attendance/[attendanceId]/page.tsx
@@ -1,14 +1,7 @@
 'use client';
 
-import {
-  useState,
-  useCallback
-} from 'react';
-import {
-  DndContext,
-  closestCenter,
-  DragEndEvent
-} from '@dnd-kit/core';
+import { useState, useCallback } from 'react';
+import { DndContext, closestCenter, DragEndEvent } from '@dnd-kit/core';
 import {
   SortableContext,
   arrayMove,
@@ -25,22 +18,6 @@ import {
 } from '@/components/atoms/Sidebar';
 
 export default function Page() {
-  const handleDragEnd = useCallback((event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
-
-    setChapters((prevChapters) => {
-      const oldIndex = prevChapters.findIndex(
-        (chapter) => chapter.id === active.id
-      );
-      const newIndex = prevChapters.findIndex(
-        (chapter) => chapter.id === over.id
-      );
-
-      return arrayMove(prevChapters, oldIndex, newIndex);
-    });
-  }, []);
-
   const [chapters, setChapters] = useState([
     {
       id: 'chapter-1',
@@ -56,6 +33,23 @@ export default function Page() {
       lessons: [{ id: 'lesson-3', title: 'レッスン3', isCompleted: false }],
     },
   ]);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    setChapters((prevChapters) => {
+      const oldIndex = prevChapters.findIndex(
+        (chapter) => chapter.id === active.id,
+      );
+      const newIndex = prevChapters.findIndex(
+        (chapter) => chapter.id === over.id,
+      );
+
+      return arrayMove(prevChapters, oldIndex, newIndex);
+    });
+  }, []);
+
   return (
     <SidebarProvider>
       <CourseSidebar />
@@ -88,20 +82,14 @@ export default function Page() {
             onDragEnd={handleDragEnd}
           >
             <SortableContext
-              items={chapters.map(ch => ch.id)}
+              items={chapters.map((ch) => ch.id)}
               strategy={verticalListSortingStrategy}
             >
               {chapters.map((chapter) => (
-                <ChapterAccordion
-                  key={chapter.id}
-                  chapter={chapter}
-                />
+                <ChapterAccordion key={chapter.id} chapter={chapter} />
               ))}
             </SortableContext>
           </DndContext>
-          {chapters.map((chapter) => (
-            <ChapterAccordion key={chapter.id} chapter={chapter} />
-          ))}
         </main>
       </SidebarInset>
     </SidebarProvider>

--- a/src/features/attendance/components/ChapterAccordion/ChapterAccordion.tsx
+++ b/src/features/attendance/components/ChapterAccordion/ChapterAccordion.tsx
@@ -1,7 +1,19 @@
-// ChapterAccordion.tsx
-import { useState } from "react"
-import { ChapterAccordionUI } from "./ChapterAccordion.ui"
-import { LessonItem } from "../LessonItem/LessonItem"
+import { useState } from "react";
+import { ChapterAccordionUI } from "./ChapterAccordion.ui";
+import { LessonItem } from "../LessonItem/LessonItem";
+import { CSS } from '@dnd-kit/utilities';
+import {
+  DndContext,
+  closestCenter,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  useSortable,
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+
 
 type Lesson = {
   id: string
@@ -24,25 +36,72 @@ export function ChapterAccordion({ chapter }: ChapterAccordionProps) {
 
   const handleToggle = () => {
     setIsOpen(prev => !prev)
-  }
+  };
 
-  const completedLessonCount = chapter.lessons.filter(
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: chapter.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const [
+    lessons, 
+    setLessons,
+  ] = useState(chapter.lessons);
+
+  const completedLessonCount = lessons.filter(
     lesson => lesson.isCompleted
-  ).length
+  ).length;
 
-  const totalLessonCount = chapter.lessons.length
+  const totalLessonCount = lessons.length;
+
+  const handleLessonDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    setLessons((prev) => {
+      const oldIndex = prev.findIndex(l => l.id === active.id);
+      const newIndex = prev.findIndex(l => l.id === over.id);
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  };
 
   return (
-    <ChapterAccordionUI
-      title={chapter.title}
-      isOpen={isOpen}
-      completedLessonCount={completedLessonCount}
-      totalLessonCount={totalLessonCount}
-      onToggle={handleToggle}
-    >
-      {chapter.lessons.map(lesson => (
-        <LessonItem key={lesson.id} lesson={lesson} />
-      ))}
-    </ChapterAccordionUI>
-  )
+    <div ref={setNodeRef} style={style}>
+      <ChapterAccordionUI
+        title={chapter.title}
+        isOpen={isOpen}
+        completedLessonCount={completedLessonCount}
+        totalLessonCount={totalLessonCount}
+        onToggle={handleToggle}
+        dragHandleProps={{ ...attributes, ...listeners }}
+      >
+        {isOpen && (
+          <DndContext
+            collisionDetection={closestCenter}
+            onDragEnd={handleLessonDragEnd}
+          >
+            <SortableContext
+              items={lessons.map(l => l.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {lessons.map(lesson => (
+                <LessonItem
+                  key={lesson.id}
+                  lesson={lesson}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+        )}
+      </ChapterAccordionUI>
+    </div>
+  );
 }

--- a/src/features/attendance/components/ChapterAccordion/ChapterAccordion.tsx
+++ b/src/features/attendance/components/ChapterAccordion/ChapterAccordion.tsx
@@ -1,31 +1,15 @@
-import { useState } from "react";
-import { ChapterAccordionUI } from "./ChapterAccordion.ui";
-import { LessonItem } from "../LessonItem/LessonItem";
+import { useState } from 'react';
+import { ChapterAccordionUI } from './ChapterAccordion.ui';
+import { LessonItem } from '../LessonItem/LessonItem';
 import { CSS } from '@dnd-kit/utilities';
-import {
-  DndContext,
-  closestCenter,
-  DragEndEvent,
-} from '@dnd-kit/core';
+import { DndContext, closestCenter, DragEndEvent } from '@dnd-kit/core';
 import {
   useSortable,
   SortableContext,
   arrayMove,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-
-
-type Lesson = {
-  id: string
-  title: string
-  isCompleted: boolean
-}
-
-type Chapter = {
-  id: string
-  title: string
-  lessons: Lesson[]
-}
+import type { Chapter } from '@/features/attendance/types';
 
 type ChapterAccordionProps = {
   chapter: Chapter;
@@ -35,29 +19,21 @@ export function ChapterAccordion({ chapter }: ChapterAccordionProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleToggle = () => {
-    setIsOpen(prev => !prev)
+    setIsOpen((prev) => !prev);
   };
 
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-  } = useSortable({ id: chapter.id });
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: chapter.id });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
   };
 
-  const [
-    lessons,
-    setLessons,
-  ] = useState(chapter.lessons);
+  const [lessons, setLessons] = useState(chapter.lessons);
 
   const completedLessonCount = lessons.filter(
-    lesson => lesson.isCompleted
+    (lesson) => lesson.isCompleted,
   ).length;
 
   const totalLessonCount = lessons.length;
@@ -67,8 +43,8 @@ export function ChapterAccordion({ chapter }: ChapterAccordionProps) {
     if (!over || active.id === over.id) return;
 
     setLessons((prev) => {
-      const oldIndex = prev.findIndex(l => l.id === active.id);
-      const newIndex = prev.findIndex(l => l.id === over.id);
+      const oldIndex = prev.findIndex((l) => l.id === active.id);
+      const newIndex = prev.findIndex((l) => l.id === over.id);
       return arrayMove(prev, oldIndex, newIndex);
     });
   };
@@ -89,14 +65,11 @@ export function ChapterAccordion({ chapter }: ChapterAccordionProps) {
             onDragEnd={handleLessonDragEnd}
           >
             <SortableContext
-              items={lessons.map(l => l.id)}
+              items={lessons.map((l) => l.id)}
               strategy={verticalListSortingStrategy}
             >
-              {lessons.map(lesson => (
-                <LessonItem
-                  key={lesson.id}
-                  lesson={lesson}
-                />
+              {lessons.map((lesson) => (
+                <LessonItem key={lesson.id} lesson={lesson} />
               ))}
             </SortableContext>
           </DndContext>

--- a/src/features/attendance/components/ChapterAccordion/ChapterAccordion.ui.tsx
+++ b/src/features/attendance/components/ChapterAccordion/ChapterAccordion.ui.tsx
@@ -1,15 +1,16 @@
 import { Button } from '@/components/atoms/Button';
 import { cn } from '@/lib/utils';
+import { GripVertical } from 'lucide-react';
 
 type ChapterAccordionUIProps = {
-  title: string
-  isOpen: boolean
-  completedLessonCount: number
-  totalLessonCount: number
-  onToggle: () => void
-  children: React.ReactNode
-  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>
-}
+  title: string;
+  isOpen: boolean;
+  completedLessonCount: number;
+  totalLessonCount: number;
+  onToggle: () => void;
+  children: React.ReactNode;
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
+};
 
 export function ChapterAccordionUI({
   title,
@@ -21,7 +22,7 @@ export function ChapterAccordionUI({
   dragHandleProps,
 }: ChapterAccordionUIProps) {
   return (
-    <div className="mb-2 rounded border">
+    <div className="rounded border">
       {/* Header */}
       <Button
         type="button"
@@ -39,7 +40,7 @@ export function ChapterAccordionUI({
           className="cursor-grab text-gray-400"
           onClick={(e) => e.stopPropagation()}
         >
-          ☰
+          <GripVertical className="h-4 w-4" />
         </div>
 
         <span className="font-medium">{title}</span>

--- a/src/features/attendance/components/ChapterAccordion/ChapterAccordion.ui.tsx
+++ b/src/features/attendance/components/ChapterAccordion/ChapterAccordion.ui.tsx
@@ -5,6 +5,7 @@ type ChapterAccordionUIProps = {
   totalLessonCount: number
   onToggle: () => void
   children: React.ReactNode
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>
 }
 
 export function ChapterAccordionUI({
@@ -14,6 +15,7 @@ export function ChapterAccordionUI({
   totalLessonCount,
   onToggle,
   children,
+  dragHandleProps,
 }: ChapterAccordionUIProps) {
   return (
     <div className="border rounded mb-2">
@@ -23,6 +25,15 @@ export function ChapterAccordionUI({
         onClick={onToggle}
         className="w-full flex justify-between items-center px-4 py-2 bg-gray-100"
       >
+        {/* ★ ドラッグハンドル */}
+        <div
+          {...dragHandleProps}
+          className="cursor-grab text-gray-400"
+          onClick={(e) => e.stopPropagation()}
+        >
+          ☰
+        </div>
+        
         <span className="font-medium">{title}</span>
         <span className="text-sm text-gray-500">
           {completedLessonCount} / {totalLessonCount} 完了

--- a/src/features/attendance/components/LessonItem/LessonItem.tsx
+++ b/src/features/attendance/components/LessonItem/LessonItem.tsx
@@ -1,4 +1,6 @@
-import { LessonItemUI } from "./LessonItem.ui"
+import { LessonItemUI } from "./LessonItem.ui";
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 type Lesson = {
   id: string
@@ -11,10 +13,26 @@ type LessonItemProps = {
 }
 
 export function LessonItem({ lesson }: LessonItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: lesson.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
   return (
-    <LessonItemUI
-      title={lesson.title}
-      isCompleted={lesson.isCompleted}
-    />
-  )
+    <div ref={setNodeRef} style={style}>
+      <LessonItemUI
+        title={lesson.title}
+        isCompleted={lesson.isCompleted}
+        dragHandleProps={{ ...attributes, ...listeners }}
+      />
+    </div>
+  );
 }

--- a/src/features/attendance/components/LessonItem/LessonItem.tsx
+++ b/src/features/attendance/components/LessonItem/LessonItem.tsx
@@ -1,25 +1,15 @@
-import { LessonItemUI } from "./LessonItem.ui";
+import { LessonItemUI } from './LessonItem.ui';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-
-type Lesson = {
-  id: string
-  title: string
-  isCompleted: boolean
-}
+import type { Lesson } from '@/features/attendance/types';
 
 type LessonItemProps = {
   lesson: Lesson;
 };
 
 export function LessonItem({ lesson }: LessonItemProps) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-  } = useSortable({ id: lesson.id });
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: lesson.id });
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/src/features/attendance/components/LessonItem/LessonItem.ui.tsx
+++ b/src/features/attendance/components/LessonItem/LessonItem.ui.tsx
@@ -1,8 +1,10 @@
+import { cn } from '@/lib/utils';
+import { CheckCircle, Circle, GripVertical } from 'lucide-react';
 type LessonItemUIProps = {
-  title: string
-  isCompleted: boolean
-  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>
-}
+  title: string;
+  isCompleted: boolean;
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
+};
 
 export function LessonItemUI({
   title,
@@ -10,22 +12,22 @@ export function LessonItemUI({
   dragHandleProps,
 }: LessonItemUIProps) {
   return (
-    <div className="flex items-center gap-2 py-2 px-3 border-b">
-      {/* ☰ ドラッグハンドル */}
+    <div className="flex items-center gap-2 border-b px-3 py-2">
       <div
         {...dragHandleProps}
         className="cursor-grab text-gray-400"
         onClick={(e) => e.stopPropagation()}
       >
-        ☰
+        <GripVertical className="h-4 w-4" />
       </div>
-
       <span>
-        {isCompleted ? "✅" : "◻️"}
+        {isCompleted ? (
+          <CheckCircle className="h-5 w-5 text-green-500" />
+        ) : (
+          <Circle className="h-5 w-5 text-gray-400" />
+        )}{' '}
       </span>
-      <span
-        className={isCompleted ? "text-gray-400 line-through" : ""}
-      >
+      <span className={cn(isCompleted && 'text-gray-400 line-through')}>
         {title}
       </span>
     </div>

--- a/src/features/attendance/components/LessonItem/LessonItem.ui.tsx
+++ b/src/features/attendance/components/LessonItem/LessonItem.ui.tsx
@@ -1,14 +1,25 @@
 type LessonItemUIProps = {
   title: string
   isCompleted: boolean
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>
 }
 
 export function LessonItemUI({
   title,
   isCompleted,
+  dragHandleProps,
 }: LessonItemUIProps) {
   return (
     <div className="flex items-center gap-2 py-2 px-3 border-b">
+      {/* ☰ ドラッグハンドル */}
+      <div
+        {...dragHandleProps}
+        className="cursor-grab text-gray-400"
+        onClick={(e) => e.stopPropagation()}
+      >
+        ☰
+      </div>
+      
       <span>
         {isCompleted ? "✅" : "◻️"}
       </span>


### PR DESCRIPTION
## Jira
JKA-1612

## 概要
受講生向けの講座詳細ページに表示する  
カリキュラム一覧（チャプター・レッスン）の並び替え機能を実装しました。

本 PR では、dnd-kit を用いて以下の Drag & Drop 操作を可能にしています。

- チャプター同士の並び替え
- 各チャプター内でのレッスン並び替え

操作可能であることが分かるよう、  
チャプター・レッスンともにドラッグハンドル（☰）を表示しています。


## 実装内容
- dnd-kit を用いた Drag & Drop 機能の実装
  - チャプターの並び替え
  - 各チャプター内でのレッスン並び替え
- ドラッグ可能範囲をハンドル（☰）に限定し、
  アコーディオン開閉やクリック操作との競合を防止
- 並び替えロジックは配列を管理するコンポーネント側に集約
  - チャプター：ページコンポーネントで管理
  - レッスン：各 ChapterAccordion 内で管理


## 対象コンポーネント

```
src/features/attendance/components/
  ChapterAccordion/
    ChapterAccordion.tsx      # Container（Chapter / Lesson DnD 管理）
    ChapterAccordion.ui.tsx   # Presentational
  LessonItem/
    LessonItem.tsx            # Container（Sortable）
    LessonItem.ui.tsx         # Presentational
```

## 実装方針
- Container / Presentational パターンを維持
- 並び順を変更する責務は、state を管理するコンポーネントに集約
- UI コンポーネントには `dragHandleProps` のみを渡し、
  dnd-kit への依存が Presentational 側に漏れない構成としています
- 並び替え結果はローカル state のみで管理し、
  API 連携は本 PR では行っていません


## 動作確認手順
1. 受講生向け講座詳細ページにアクセス  
   `/attendance/[attendanceId]`
2. チャプターのドラッグ&ドロップで並び替えができることを確認
3. チャプター内でレッスンのドラッグ&ドロップができることを確認
4. ドラッグハンドル（☰）操作時にのみ並び替えが行われることを確認
5. アコーディオンの開閉操作と Drag & Drop が干渉しないことを確認


## 補足
- 本 PR では表示確認用として仮データを使用しています
- 並び順の永続化（API 連携）は今後のタスクで対応予定です

