### PR TITLE
JKA-1615 React 型定義: 出席講座APIレスポンスの型を作成（ちゃこ）

### DIFF
--- a/src/features/attendance/types/attendance.ts
+++ b/src/features/attendance/types/attendance.ts
@@ -1,3 +1,5 @@
+import type { PaginationLinks, PaginationMeta } from '@/types/pagination';
+
 export type Tag = {
   tag_id: string;
   content: string;
@@ -15,28 +17,6 @@ export type Attendance = {
   deadline_date: string;
   expired: string;
   course: Course;
-};
-
-export type PaginationLinks = {
-  first: string;
-  last: string;
-  prev: string | null;
-  next: string | null;
-};
-
-export type PaginationMeta = {
-  current_page: number;
-  from: number;
-  last_page: number;
-  links: {
-    url: string | null;
-    label: string;
-    active: boolean;
-  }[];
-  path: string;
-  per_page: number;
-  to: number;
-  total: number;
 };
 
 export type AttendancesResponse = {

--- a/src/features/attendance/types/attendance.ts
+++ b/src/features/attendance/types/attendance.ts
@@ -1,0 +1,46 @@
+export type Tag = {
+  tag_id: string;
+  content: string;
+};
+
+export type Course = {
+  course_id: string;
+  title: string;
+  image: string;
+  tags: Tag[];
+};
+
+export type Attendance = {
+  attendance_id: string;
+  deadline_date: string;
+  expired: string;
+  course: Course;
+};
+
+export type PaginationLinks = {
+  first: string;
+  last: string;
+  prev: string | null;
+  next: string | null;
+};
+
+export type PaginationMeta = {
+  current_page: number;
+  from: number;
+  last_page: number;
+  links: {
+    url: string | null;
+    label: string;
+    active: boolean;
+  }[];
+  path: string;
+  per_page: number;
+  to: number;
+  total: number;
+};
+
+export type AttendancesResponse = {
+  data: Attendance[];
+  links: PaginationLinks;
+  meta: PaginationMeta;
+};

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,21 @@
+export type PaginationLinks = {
+  first: string;
+  last: string;
+  prev: string | null;
+  next: string | null;
+};
+
+export type PaginationMeta = {
+  current_page: number;
+  from: number;
+  last_page: number;
+  links: {
+    url: string | null;
+    label: string;
+    active: boolean;
+  }[];
+  path: string;
+  per_page: number;
+  to: number;
+  total: number;
+};


### PR DESCRIPTION
## Jira
JKA-1615

## 概要
生徒向け出席講座一覧画面で利用する  
出席講座API（`/api/v1/attendance/index`）のレスポンス型定義を追加しました。

`src/app/(student)/attendance/page.tsx` にて
APIレスポンスを型安全に扱えるようにすることを目的としています。

`pnpm type-check` を実行し、エラーがないことも確認しています。

## 対応内容
- 出席講座APIレスポンス用の型定義を新規作成
- Tag / Course / Attendance / Pagination を含むレスポンス構造を定義
- 今後の画面実装・API連携で再利用できるよう、features 配下に配置

## 対象ファイル
- `src/features/attendance/types/attendance.ts`（新規作成）

## 動作確認手順
- `pnpm type-check` を実行
- TypeScript の型エラーが発生しないことを確認

## 考慮事項
- 本PRでは型定義のみを対象とし、API呼び出し処理や画面側の修正は行っていません
- 実際のデータ取得・表示処理は後続タスクで対応予定です
