### PR TITLE
JKA-1617 React 出席講座一覧のスケルトンコンポーネントを作成（ちゃこ）

### DIFF
--- a/src/components/atoms/Skeleton.tsx
+++ b/src/components/atoms/Skeleton.tsx
@@ -1,0 +1,1 @@
+export { Skeleton } from "@/components/ui/skeleton";

--- a/src/components/atoms/Skeleton.tsx
+++ b/src/components/atoms/Skeleton.tsx
@@ -1,1 +1,1 @@
-export { Skeleton } from "@/components/ui/skeleton";
+export { Skeleton } from '@/components/ui/skeleton';

--- a/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.skeleton.tsx
+++ b/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.skeleton.tsx
@@ -1,10 +1,10 @@
-import { Skeleton } from "@/components/atoms/Skeleton";
+import { Skeleton } from '@/components/atoms/Skeleton';
 
 export function AttendancedCourseCardListSkeleton() {
   return (
     <div className="mx-auto grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {[...Array(6)].map((_, i) => (
-        <div key={i} className="border rounded-lg p-4 space-y-3">
+        <div key={i} className="space-y-3 rounded-lg border p-4">
           <Skeleton className="h-40 w-full rounded" />
           <Skeleton className="h-5 w-3/4" />
           <Skeleton className="h-4 w-1/2" />

--- a/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.skeleton.tsx
+++ b/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.skeleton.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from "@/components/atoms/Skeleton";
+
+export function AttendancedCourseCardListSkeleton() {
+  return (
+    <div className="mx-auto grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {[...Array(6)].map((_, i) => (
+        <div key={i} className="border rounded-lg p-4 space-y-3">
+          <Skeleton className="h-40 w-full rounded" />
+          <Skeleton className="h-5 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-3 w-full" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/attendance/hooks/useAttendances.ts
+++ b/src/features/attendance/hooks/useAttendances.ts
@@ -12,7 +12,7 @@ const fetcher = async (url: string): Promise<AttendancesResponse> => {
 };
 
 export function useAttendances() {
-  const { data, error, isLoading } = useSWR<AttendancesResponse>(
+  const { data, error } = useSWR<AttendancesResponse>(
     "/api/v1/attendance/index",
     fetcher,
     { suspense: true }
@@ -23,6 +23,5 @@ export function useAttendances() {
     meta: data?.meta,
     links: data?.links,
     error,
-    isLoading,
   };
 }

--- a/src/features/attendance/hooks/useAttendances.ts
+++ b/src/features/attendance/hooks/useAttendances.ts
@@ -4,7 +4,7 @@ import type { AttendancesResponse } from '../types/attendance';
 
 export function useAttendances() {
   const { data, error } = useSWR<AttendancesResponse>(
-    "/api/v1/attendance/index",
+    '/api/v1/attendance/index',
     fetcher,
     { suspense: true },
   );


### PR DESCRIPTION
## Jira
JKA-1617

## 概要
出席講座一覧画面のローディング時に表示する
スケルトンUIコンポーネントを新規作成しました。

Suspense の `fallback` として使用することを想定し、
ローディング中でも既存カードレイアウトに近い形で
表示されるよう対応しています。

## 対応内容
- 出席講座一覧用のスケルトンコンポーネントを新規作成
- 既存の `AttendancedCourseCardList` の grid レイアウトに合わせた構造を実装
- 画面サイズに応じた一覧感が分かるよう、
  Skeleton カードは 6 件（lg サイズで 3 列 × 2 行想定）表示
- Skeleton コンポーネントは atoms 経由で利用できるようラッパーを追加

## 対象ファイル
- `src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.skeleton.tsx`（新規作成）
- `src/components/atoms/Skeleton.tsx`（新規作成）

## 動作確認手順
- `pnpm type-check` を実行し、TypeScript エラーが発生しないことを確認
- `pnpm lint` を実行

## 考慮事項
- `pnpm lint` 実行時に既存ファイル  
  `src/features/student/components/SignupForm/SignupForm.tsx` にて  
  `@typescript-eslint/no-explicit-any` のエラーが発生しますが、
  本PRの変更内容とは無関係のため対応対象外としています。
