### PR TITLE
JKA-1720 React AttendancedCourseCardList に講師名を表示する（ちゃこ）

### DIFF
--- a/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.tsx
+++ b/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.tsx
@@ -2,18 +2,21 @@ import { AttendancedCourseCardUI } from './AttendancedCourseCard.ui';
 
 type AttendancedCourseCardProps = {
   title: string;
+  instructorName: string;
   isExpired: boolean;
   progress: number;
 };
 
 export function AttendancedCourseCard({
   title,
+  instructorName,
   isExpired,
   progress,
 }: AttendancedCourseCardProps) {
   return (
     <AttendancedCourseCardUI
       title={title}
+      instructorName={instructorName}
       isExpired={isExpired}
       progress={progress}
     />

--- a/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.ui.tsx
+++ b/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.ui.tsx
@@ -1,13 +1,16 @@
 import { Card } from '@/components/atoms/Card';
+import { CircleUserRound } from 'lucide-react';
 
 type AttendancedCourseCardUIProps = {
   title: string;
+  instructorName: string;
   isExpired: boolean;
   progress: number;
 };
 
 export function AttendancedCourseCardUI({
   title,
+  instructorName,
   isExpired,
   progress,
 }: AttendancedCourseCardUIProps) {
@@ -27,6 +30,12 @@ export function AttendancedCourseCardUI({
               受講期限切れ
             </span>
           )}
+        </div>
+
+         {/* 講師名 */}
+        <div className="flex items-center gap-1 text-xs text-gray-700">
+          <CircleUserRound className="h-4 w-4" />
+          <span>{instructorName}</span>
         </div>
         {/* 進捗 */}
         <p className="text-muted-foreground text-xs">進捗 {progress}%</p>

--- a/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.ui.tsx
+++ b/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.ui.tsx
@@ -32,7 +32,6 @@ export function AttendancedCourseCardUI({
           )}
         </div>
 
-         {/* 講師名 */}
         <div className="flex items-center gap-1 text-xs text-gray-700">
           <CircleUserRound className="h-4 w-4" />
           <span>{instructorName}</span>

--- a/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.tsx
+++ b/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.tsx
@@ -9,6 +9,7 @@ export function AttendancedCourseCardList() {
   const courses = attendances.map((attendance) => ({
     id: attendance.attendance_id,
     title: attendance.course.title,
+    instructorName: `${attendance.course.instructor.last_name} ${attendance.course.instructor.first_name}`,
     progress: 77,
     isExpired: attendance.expired,
   }));

--- a/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.ui.tsx
+++ b/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.ui.tsx
@@ -5,6 +5,7 @@ import { AttendancedCourseCard } from '../AttendancedCourseCard/AttendancedCours
 type Course = {
   id: string;
   title: string;
+  instructorName: string;
   progress: number;
   isExpired: boolean;
 };
@@ -22,6 +23,7 @@ export function AttendancedCourseCardListUI({
         <AttendancedCourseCard
           key={course.id}
           title={course.title}
+          instructorName={course.instructorName}
           progress={course.progress}
           isExpired={course.isExpired}
         />

--- a/src/features/attendance/types/attendance.ts
+++ b/src/features/attendance/types/attendance.ts
@@ -5,11 +5,21 @@ export type Tag = {
   content: string;
 };
 
+export type Instructor = {
+  instructor_id: string;
+  first_name: string;
+  last_name: string;
+  nick_name: string;
+  email: string;
+  profile_image: string;
+};
+
 export type Course = {
   course_id: string;
   title: string;
   image: string;
   tags: Tag[];
+  instructor: Instructor;
 };
 
 export type Attendance = {


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-1720


## 概要

生徒向け出席講座一覧ページ（/attendance）において、各講座カードに講師名を表示する対応を行いました。

バックエンド API のレスポンス構造変更により、`course` 内に `instructor` 情報が追加されたため、  
フロント側で型定義を更新し、講座カードに講師名を表示するよう実装しています。

講師名は API レスポンスの `instructor.last_name` / `instructor.first_name` を組み合わせて表示しています。


## 対応内容

- API レスポンス構造に合わせて `attendance.ts` の型定義を更新
- `Course` 型に `instructor` 情報を追加
- `AttendancedCourseCardList.tsx` にて講師名を取得し、UI 用データへマッピング
- `AttendancedCourseCardListUI` → `AttendancedCourseCard` → `AttendancedCourseCardUI` の props に講師名を追加
- 講座カード内に講師名を表示
- 講師名の左側にユーザーアイコンを追加

## 動作確認手順

1. `/attendance` にアクセスする  
2. 各講座カードに講師名が表示されることを確認する  
3. 講師名が API の `instructor` 情報と一致していることを確認する  


## 確認項目

- 講座カードに講師名が表示されること  
- API レスポンスの `instructor` 情報が正しく取得できていること  
- UI レイアウトが崩れていないこと  
- `pnpm type-check` が通ること  