### PR TITLE
JKA-1721 React 受講講座カードクリックで講座詳細ページへ遷移する(ちゃこ)

### DIFF
--- a/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.tsx
+++ b/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.tsx
@@ -1,6 +1,7 @@
 import { AttendancedCourseCardUI } from './AttendancedCourseCard.ui';
 
 type AttendancedCourseCardProps = {
+  attendanceId: number | string;
   title: string;
   instructorName: string;
   isExpired: boolean;
@@ -8,13 +9,17 @@ type AttendancedCourseCardProps = {
 };
 
 export function AttendancedCourseCard({
+  attendanceId,
   title,
   instructorName,
   isExpired,
   progress,
 }: AttendancedCourseCardProps) {
+  const href = `/attendance/${attendanceId}`;
+
   return (
     <AttendancedCourseCardUI
+      href={href}
       title={title}
       instructorName={instructorName}
       isExpired={isExpired}

--- a/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.tsx
+++ b/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.tsx
@@ -1,7 +1,8 @@
+import Link from 'next/link';
 import { AttendancedCourseCardUI } from './AttendancedCourseCard.ui';
 
 type AttendancedCourseCardProps = {
-  attendanceId: number | string;
+  attendanceId: string;
   title: string;
   instructorName: string;
   isExpired: boolean;
@@ -18,12 +19,14 @@ export function AttendancedCourseCard({
   const href = `/attendance/${attendanceId}`;
 
   return (
-    <AttendancedCourseCardUI
-      href={href}
-      title={title}
-      instructorName={instructorName}
-      isExpired={isExpired}
-      progress={progress}
-    />
+    <Link href={href} className="block w-full max-w-[350px]">
+      <AttendancedCourseCardUI
+        href={href}
+        title={title}
+        instructorName={instructorName}
+        isExpired={isExpired}
+        progress={progress}
+      />
+    </Link>
   );
 }

--- a/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.tsx
+++ b/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.tsx
@@ -21,7 +21,6 @@ export function AttendancedCourseCard({
   return (
     <Link href={href} className="block w-full max-w-[350px]">
       <AttendancedCourseCardUI
-        href={href}
         title={title}
         instructorName={instructorName}
         isExpired={isExpired}

--- a/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.ui.tsx
+++ b/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.ui.tsx
@@ -1,9 +1,7 @@
-import Link from 'next/link';
 import { Card } from '@/components/atoms/Card';
 import { CircleUserRound } from 'lucide-react';
 
 type AttendancedCourseCardUIProps = {
-  href: string;
   title: string;
   instructorName: string;
   isExpired: boolean;
@@ -11,39 +9,36 @@ type AttendancedCourseCardUIProps = {
 };
 
 export function AttendancedCourseCardUI({
-  href,
   title,
   instructorName,
   isExpired,
   progress,
 }: AttendancedCourseCardUIProps) {
   return (
-    <Link href={href} className="block w-full max-w-[350px]">
-      <Card className="overflow-hidden rounded-md border bg-transparent p-0 hover:opacity-80">
-        {/* サムネイル */}
-        <div className="flex aspect-[16/9] w-full items-center justify-center bg-indigo-400">
-          <span className="text-sm font-semibold text-black">サムネイル</span>
+    <Card className="overflow-hidden rounded-md border bg-transparent p-0 hover:opacity-80">
+      {/* サムネイル */}
+      <div className="flex aspect-[16/9] w-full items-center justify-center bg-indigo-400">
+        <span className="text-sm font-semibold text-black">サムネイル</span>
+      </div>
+      {/* 下段 */}
+      <div className="space-y-1.5 bg-white p-3">
+        {/* タイトル + 受講期限切れ */}
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-semibold">{title}</p>
+          {isExpired && (
+            <span className="text-xs font-semibold text-red-600">
+              受講期限切れ
+            </span>
+          )}
         </div>
-        {/* 下段 */}
-        <div className="space-y-1.5 bg-white p-3">
-          {/* タイトル + 受講期限切れ */}
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-semibold">{title}</p>
-            {isExpired && (
-              <span className="text-xs font-semibold text-red-600">
-                受講期限切れ
-              </span>
-            )}
-          </div>
 
-          <div className="flex items-center gap-1 text-xs text-gray-700">
-            <CircleUserRound className="h-4 w-4" />
-            <span>{instructorName}</span>
-          </div>
-          {/* 進捗 */}
-          <p className="text-muted-foreground text-xs">進捗 {progress}%</p>
+        <div className="flex items-center gap-1 text-xs text-gray-700">
+          <CircleUserRound className="h-4 w-4" />
+          <span>{instructorName}</span>
         </div>
-      </Card>
-    </Link>
+        {/* 進捗 */}
+        <p className="text-muted-foreground text-xs">進捗 {progress}%</p>
+      </div>
+    </Card>
   );
 }

--- a/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.ui.tsx
+++ b/src/features/attendance/components/AttendancedCourseCard/AttendancedCourseCard.ui.tsx
@@ -1,7 +1,9 @@
+import Link from 'next/link';
 import { Card } from '@/components/atoms/Card';
 import { CircleUserRound } from 'lucide-react';
 
 type AttendancedCourseCardUIProps = {
+  href: string;
   title: string;
   instructorName: string;
   isExpired: boolean;
@@ -9,36 +11,39 @@ type AttendancedCourseCardUIProps = {
 };
 
 export function AttendancedCourseCardUI({
+  href,
   title,
   instructorName,
   isExpired,
   progress,
 }: AttendancedCourseCardUIProps) {
   return (
-    <Card className="w-full max-w-[350px] overflow-hidden rounded-md border bg-transparent p-0">
-      {/* サムネイル */}
-      <div className="flex aspect-[16/9] w-full items-center justify-center bg-indigo-400">
-        <span className="text-sm font-semibold text-black">サムネイル</span>
-      </div>
-      {/* 下段 */}
-      <div className="space-y-1.5 bg-white p-3">
-        {/* タイトル + 受講期限切れ */}
-        <div className="flex items-center justify-between">
-          <p className="text-sm font-semibold">{title}</p>
-          {isExpired && (
-            <span className="text-xs font-semibold text-red-600">
-              受講期限切れ
-            </span>
-          )}
+    <Link href={href} className="block w-full max-w-[350px]">
+      <Card className="overflow-hidden rounded-md border bg-transparent p-0 hover:opacity-80">
+        {/* サムネイル */}
+        <div className="flex aspect-[16/9] w-full items-center justify-center bg-indigo-400">
+          <span className="text-sm font-semibold text-black">サムネイル</span>
         </div>
+        {/* 下段 */}
+        <div className="space-y-1.5 bg-white p-3">
+          {/* タイトル + 受講期限切れ */}
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold">{title}</p>
+            {isExpired && (
+              <span className="text-xs font-semibold text-red-600">
+                受講期限切れ
+              </span>
+            )}
+          </div>
 
-        <div className="flex items-center gap-1 text-xs text-gray-700">
-          <CircleUserRound className="h-4 w-4" />
-          <span>{instructorName}</span>
+          <div className="flex items-center gap-1 text-xs text-gray-700">
+            <CircleUserRound className="h-4 w-4" />
+            <span>{instructorName}</span>
+          </div>
+          {/* 進捗 */}
+          <p className="text-muted-foreground text-xs">進捗 {progress}%</p>
         </div>
-        {/* 進捗 */}
-        <p className="text-muted-foreground text-xs">進捗 {progress}%</p>
-      </div>
-    </Card>
+      </Card>
+    </Link>
   );
 }

--- a/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.tsx
+++ b/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.tsx
@@ -7,7 +7,7 @@ export function AttendancedCourseCardList() {
   const { attendances } = useAttendances();
 
   const courses = attendances.map((attendance) => ({
-    id: attendance.attendance_id,
+    attendanceId: attendance.attendance_id,
     title: attendance.course.title,
     instructorName: `${attendance.course.instructor.last_name} ${attendance.course.instructor.first_name}`,
     progress: 77,

--- a/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.ui.tsx
+++ b/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.ui.tsx
@@ -3,7 +3,7 @@
 import { AttendancedCourseCard } from '../AttendancedCourseCard/AttendancedCourseCard';
 
 type Course = {
-  id: string;
+  attendanceId: number | string;
   title: string;
   instructorName: string;
   progress: number;
@@ -21,7 +21,8 @@ export function AttendancedCourseCardListUI({
     <div className="mx-auto grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {courses.map((course) => (
         <AttendancedCourseCard
-          key={course.id}
+          key={course.attendanceId}
+          attendanceId={course.attendanceId}
           title={course.title}
           instructorName={course.instructorName}
           progress={course.progress}

--- a/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.ui.tsx
+++ b/src/features/attendance/components/AttendancedCourseCardList/AttendancedCourseCardList.ui.tsx
@@ -3,7 +3,7 @@
 import { AttendancedCourseCard } from '../AttendancedCourseCard/AttendancedCourseCard';
 
 type Course = {
-  attendanceId: number | string;
+  attendanceId: string;
   title: string;
   instructorName: string;
   progress: number;


### PR DESCRIPTION
## Issue
https://gut-familie.atlassian.net/browse/JKA-1721


## 概要
生徒向け出席講座一覧ページ（/attendance）において、各講座カードをクリックした際に講座詳細ページへ遷移できるよう対応しました。

カード全体を `next/link` でラップし、`/attendance/[attendanceId]` へ遷移するよう実装しています。

また、遷移先 URL の生成は Container 側で行い、UI 側では受け取った `href` を用いて描画する形にすることで、Container / Presentational の責務分離を保っています。

---

## 対応内容

- `AttendancedCourseCard` に `attendanceId` を追加
- Container 側で `/attendance/${attendanceId}` の遷移 URL を生成
- `AttendancedCourseCardUI` に `href` props を追加
- カード全体を `next/link` でラップしてクリック遷移を実装
- `AttendancedCourseCardList.tsx` にて `attendanceId` を UI 用データへマッピング
- `AttendancedCourseCardListUI` → `AttendancedCourseCard` → `AttendancedCourseCardUI` の props に `attendanceId` を追加
- 講座カード関連の `id` を `attendanceId` に統一し、命名を整理
（影響するファイルは全てidからattendanceIdに変更いたしました）

---

## 動作確認手順

1. `/attendance` にアクセスする  
2. 講座カードをクリックする  
3. `/attendance/{attendanceId}` に遷移することを確認する  

---

## 確認項目

- 講座カード全体がクリック可能になっていること  
- カードクリック時に `/attendance/[attendanceId]` に遷移すること  
- 遷移先ページが正常に表示されること  
- UI レイアウトが崩れていないこと  
- `pnpm type-check` / `npm run lint` が通ること