### PR TITLE
Feture/haruka/jka 1774/add user info edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@
 
 ### 主なライブラリ
 
-| 用途 | ライブラリ |
-| --- | --- |
-| データフェッチング | SWR + axios |
-| フォーム / バリデーション | React Hook Form + zod (`@hookform/resolvers`) |
-| UIコンポーネント | shadcn/ui (Radix UI) + lucide-react (アイコン) |
-| 非同期 / エラーハンドリング | Suspense + react-error-boundary |
-| ドラッグ&ドロップ | dnd-kit |
-| 日付 | date-fns + react-day-picker |
-| Lint / フォーマット | ESLint 9 + Prettier |
+| 用途                        | ライブラリ                                     |
+| --------------------------- | ---------------------------------------------- |
+| データフェッチング          | SWR + axios                                    |
+| フォーム / バリデーション   | React Hook Form + zod (`@hookform/resolvers`)  |
+| UIコンポーネント            | shadcn/ui (Radix UI) + lucide-react (アイコン) |
+| 非同期 / エラーハンドリング | Suspense + react-error-boundary                |
+| ドラッグ&ドロップ           | dnd-kit                                        |
+| 日付                        | date-fns + react-day-picker                    |
+| Lint / フォーマット         | ESLint 9 + Prettier                            |
 
 ## 環境構築
 
@@ -55,8 +55,8 @@ pnpm install
 
 `.env.example` をコピーして `.env.local` を作成し、必要に応じて編集します。
 
-| 変数 | 説明 | 例 |
-| --- | --- | --- |
+| 変数                      | 説明                                                      | 例                              |
+| ------------------------- | --------------------------------------------------------- | ------------------------------- |
 | `NEXT_PUBLIC_STORAGE_URL` | Laravelバックエンドの Storage URL（クライアント側で参照） | `http://localhost:8080/storage` |
 
 ### 開発サーバー起動

--- a/src/app/(student)/profile/page.tsx
+++ b/src/app/(student)/profile/page.tsx
@@ -1,0 +1,5 @@
+import { EditForm } from '@/features/student/components/EditForm/EditForm';
+
+export default function StudentEditPage() {
+  return <EditForm />;
+}

--- a/src/components/organisms/Header/StudentHeader.ui.tsx
+++ b/src/components/organisms/Header/StudentHeader.ui.tsx
@@ -24,7 +24,7 @@ export function StudentHeaderUI({ userName, onLogout }: StudentHeaderUIProps) {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem asChild>
-            <Link href="#">ユーザー情報編集</Link>
+            <Link href="/profile">ユーザー情報編集</Link>
           </DropdownMenuItem>
           <DropdownMenuItem onClick={onLogout}>ログアウト</DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/features/student/components/EditForm/EditForm.tsx
+++ b/src/features/student/components/EditForm/EditForm.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useForm, type FieldErrors } from 'react-hook-form';
+import { EditFormUI } from './EditForm.ui';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  editSchema,
+  EditSchema,
+} from '@/features/student/validation/EditSchema';
+
+export function EditForm() {
+  const form = useForm<EditSchema>({
+    resolver: zodResolver(editSchema),
+    defaultValues: {
+      userName: '',
+      lastName: '',
+      firstName: '',
+      email: '',
+      occupation: '',
+      purpose: '',
+      birthday: '',
+      gender: undefined,
+      address: '',
+      profileImage: undefined,
+    },
+  });
+
+  const onSubmit = (data: EditSchema) => {
+    console.log('submit data:', data);
+  };
+  const onError = (errors: FieldErrors<EditSchema>) => {
+    console.log('submit errors:', errors);
+  };
+
+  return <EditFormUI form={form} onSubmit={onSubmit} onError={onError} />;
+}

--- a/src/features/student/components/EditForm/EditForm.ui.tsx
+++ b/src/features/student/components/EditForm/EditForm.ui.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { UseFormReturn, FieldErrors } from 'react-hook-form';
-import { Controller } from 'react-hook-form';
-import { useFormState } from 'react-hook-form';
+import {
+  UseFormReturn,
+  FieldErrors,
+  Controller,
+  useFormState,
+} from 'react-hook-form';
 import { Input } from '@/components/atoms/Input';
 import { Button } from '@/components/atoms/Button';
 import { CalendarIcon } from 'lucide-react';
@@ -15,6 +18,7 @@ import {
 import { RadioGroup, RadioGroupItem } from '@/components/atoms/RadioGroup';
 import { EditSchema } from '../../validation/EditSchema';
 import { ImageUploader } from './ImageUploader';
+import { format } from 'date-fns';
 
 type Props = {
   form: UseFormReturn<EditSchema>;
@@ -119,9 +123,7 @@ export function EditFormUI({ form, onSubmit, onError }: Props) {
                     mode="single"
                     selected={field.value ? new Date(field.value) : undefined}
                     onSelect={(date) =>
-                      field.onChange(
-                        date ? date.toISOString().split('T')[0] : '',
-                      )
+                      field.onChange(date ? format(date, 'yyyy-MM-dd') : '')
                     }
                     captionLayout="dropdown"
                   />
@@ -141,7 +143,7 @@ export function EditFormUI({ form, onSubmit, onError }: Props) {
         <div>
           <label className="block text-sm">性別</label>
           <Controller
-            control={form.control}
+            control={control}
             name="gender"
             render={({ field }) => (
               <RadioGroup

--- a/src/features/student/components/EditForm/EditForm.ui.tsx
+++ b/src/features/student/components/EditForm/EditForm.ui.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { UseFormReturn, FieldErrors } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
+import { useFormState } from 'react-hook-form';
+import { Input } from '@/components/atoms/Input';
+import { Button } from '@/components/atoms/Button';
+import { CalendarIcon } from 'lucide-react';
+import { Calendar } from '@/components/atoms/Calendar';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/atoms/Popover';
+import { RadioGroup, RadioGroupItem } from '@/components/atoms/RadioGroup';
+import { EditSchema } from '../../validation/EditSchema';
+import { ImageUploader } from './ImageUploader';
+
+type Props = {
+  form: UseFormReturn<EditSchema>;
+  onSubmit: (data: EditSchema) => void;
+  onError: (errors: FieldErrors<EditSchema>) => void;
+};
+
+export function EditFormUI({ form, onSubmit, onError }: Props) {
+  const { register, handleSubmit, control } = form;
+
+  const { errors } = useFormState({
+    control,
+  });
+
+  return (
+    <div className="flex min-h-screen items-start justify-center bg-gray-100 pt-10">
+      <form
+        onSubmit={handleSubmit(onSubmit, onError)}
+        noValidate
+        className="w-1/2 space-y-4 rounded-md bg-white p-6 shadow"
+      >
+        <h1 className="text-center text-lg font-bold">ユーザー情報編集</h1>
+
+        {/* ユーザー名 */}
+        <div>
+          <label className="block text-sm">ユーザー名</label>
+          <Input {...register('userName')} />
+          {errors.userName && (
+            <p className="text-sm text-red-500">
+              {errors.userName.message as string}
+            </p>
+          )}
+        </div>
+
+        {/* 姓 */}
+        <div>
+          <label className="block text-sm">姓</label>
+          <Input {...register('lastName')} />
+          {errors.lastName && (
+            <p className="text-sm text-red-500">
+              {errors.lastName.message as string}
+            </p>
+          )}
+        </div>
+
+        {/* 名 */}
+        <div>
+          <label className="block text-sm">名</label>
+          <Input {...register('firstName')} />
+          {errors.firstName && (
+            <p className="text-sm text-red-500">
+              {errors.firstName.message as string}
+            </p>
+          )}
+        </div>
+
+        {/* メール */}
+        <div>
+          <label className="block text-sm">メールアドレス</label>
+          <Input type="email" {...register('email')} />
+          {errors.email && (
+            <p className="text-sm text-red-500">
+              {errors.email.message as string}
+            </p>
+          )}
+        </div>
+
+        {/* 職業 */}
+        <div>
+          <label className="block text-sm">職業</label>
+          <Input {...register('occupation')} />
+        </div>
+
+        {/* 目的 */}
+        <div>
+          <label className="block text-sm">目的</label>
+          <Input {...register('purpose')} />
+        </div>
+
+        {/* 誕生日 */}
+        <div>
+          <label className="block text-sm">誕生日</label>
+          <Controller
+            control={control}
+            name="birthday"
+            render={({ field }) => (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <div className="relative">
+                    <Input
+                      readOnly
+                      value={field.value ?? ''}
+                      placeholder=""
+                      className="cursor-pointer pr-10"
+                    />
+                    <CalendarIcon className="text-muted-foreground absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2" />
+                  </div>
+                </PopoverTrigger>
+
+                <PopoverContent className="w-auto p-0">
+                  <Calendar
+                    mode="single"
+                    selected={field.value ? new Date(field.value) : undefined}
+                    onSelect={(date) =>
+                      field.onChange(
+                        date ? date.toISOString().split('T')[0] : '',
+                      )
+                    }
+                    captionLayout="dropdown"
+                  />
+                </PopoverContent>
+              </Popover>
+            )}
+          />
+
+          {errors.birthday && (
+            <p className="text-sm text-red-500">
+              {errors.birthday.message as string}
+            </p>
+          )}
+        </div>
+
+        {/* 性別 */}
+        <div>
+          <label className="block text-sm">性別</label>
+          <Controller
+            control={form.control}
+            name="gender"
+            render={({ field }) => (
+              <RadioGroup
+                className="flex gap-6"
+                value={field.value ?? ''}
+                onValueChange={field.onChange}
+              >
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="male" />
+                  <span className="text-sm">男性</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="female" />
+                  <span className="text-sm">女性</span>
+                </div>
+              </RadioGroup>
+            )}
+          />
+          {errors.gender && (
+            <p className="text-sm text-red-500">
+              {errors.gender.message as string}
+            </p>
+          )}
+        </div>
+
+        {/* 住所 */}
+        <div>
+          <label className="block text-sm">住所</label>
+          <Input {...register('address')} />
+          {errors.address && (
+            <p className="text-sm text-red-500">
+              {errors.address.message as string}
+            </p>
+          )}
+        </div>
+
+        {/* プロフィール画像 */}
+        <div>
+          <label className="block text-sm">プロフィール画像</label>
+          <Controller
+            control={control}
+            name="profileImage"
+            render={({ field }) => (
+              <ImageUploader value={field.value} onChange={field.onChange} />
+            )}
+          />
+        </div>
+
+        {/* 更新ボタン */}
+        <Button type="submit" className="w-full">
+          更新
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/features/student/components/EditForm/ImageUploader.tsx
+++ b/src/features/student/components/EditForm/ImageUploader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Upload } from 'lucide-react';
 
 type Props = {
@@ -9,21 +9,21 @@ type Props = {
 };
 
 export function ImageUploader({ value, onChange }: Props) {
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // value(File) からプレビュー用のURLを派生、生成したURLは変更・破棄時に解放
+  // value(File) からプレビュー用のURLを派生
+  const previewUrl = useMemo(
+    () => (value ? URL.createObjectURL(value) : null),
+    [value],
+  );
+
+  // 生成したURLは変更・破棄時に解放
   useEffect(() => {
-    if (!value) {
-      setPreviewUrl(null);
-      return;
-    }
-    const url = URL.createObjectURL(value);
-    setPreviewUrl(url);
-    return () => URL.revokeObjectURL(url);
-  }, [value]);
+    if (!previewUrl) return;
+    return () => URL.revokeObjectURL(previewUrl);
+  }, [previewUrl]);
 
   // ファイル選択時、画像ファイルでない場合はエラーを表示
   const handleFiles = (files: FileList | null) => {

--- a/src/features/student/components/EditForm/ImageUploader.tsx
+++ b/src/features/student/components/EditForm/ImageUploader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Upload } from 'lucide-react';
 
 type Props = {
@@ -9,26 +9,34 @@ type Props = {
 };
 
 export function ImageUploader({ value, onChange }: Props) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  // value(File) からプレビュー用のURLを派生
-  const previewUrl = useMemo(
-    () => (value ? URL.createObjectURL(value) : null),
-    [value],
-  );
-
-  // 生成したURLは変更・破棄時に解放
+  // value(File) からプレビュー用のURLを派生、生成したURLは変更・破棄時に解放
   useEffect(() => {
-    if (!previewUrl) return;
-    return () => URL.revokeObjectURL(previewUrl);
-  }, [previewUrl]);
+    if (!value) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(value);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [value]);
 
+  // ファイル選択時、画像ファイルでない場合はエラーを表示
   const handleFiles = (files: FileList | null) => {
     const file = files?.[0];
-    if (file && file.type.startsWith('image/')) {
-      onChange(file);
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      setError('画像ファイルを選択してください');
+      return;
     }
+
+    setError(null);
+    onChange(file);
   };
 
   // ドラッグ＆ドロップ領域
@@ -73,7 +81,7 @@ export function ImageUploader({ value, onChange }: Props) {
       </button>
 
       {/* プレビュー枠 */}
-      <div className="border-input flex h-30 items-center justify-center rounded-md border shadow-xs">
+      <div className="border-input flex h-28 items-center justify-center rounded-md border shadow-xs">
         {previewUrl ? (
           <img
             src={previewUrl}
@@ -91,9 +99,7 @@ export function ImageUploader({ value, onChange }: Props) {
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         className={`flex flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed py-6 text-center transition-colors ${
-          isDragging
-            ? 'border-primary bg-primary/10'
-            : 'border-input bg-white'
+          isDragging ? 'border-primary bg-primary/10' : 'border-input bg-white'
         }`}
       >
         <Upload className="h-5 w-5" />
@@ -103,6 +109,9 @@ export function ImageUploader({ value, onChange }: Props) {
           ファイルをここにドラッグアンドドロップ
         </p>
       </div>
+
+      {/* 画像以外を選択・ドロップしたときのフィードバック */}
+      {error && <p className="text-sm text-red-500">{error}</p>}
     </div>
   );
 }

--- a/src/features/student/components/EditForm/ImageUploader.tsx
+++ b/src/features/student/components/EditForm/ImageUploader.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Upload } from 'lucide-react';
+
+type Props = {
+  value?: File;
+  onChange: (file: File | undefined) => void;
+};
+
+export function ImageUploader({ value, onChange }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // value(File) からプレビュー用のURLを派生
+  const previewUrl = useMemo(
+    () => (value ? URL.createObjectURL(value) : null),
+    [value],
+  );
+
+  // 生成したURLは変更・破棄時に解放
+  useEffect(() => {
+    if (!previewUrl) return;
+    return () => URL.revokeObjectURL(previewUrl);
+  }, [previewUrl]);
+
+  const handleFiles = (files: FileList | null) => {
+    const file = files?.[0];
+    if (file && file.type.startsWith('image/')) {
+      onChange(file);
+    }
+  };
+
+  // ドラッグ＆ドロップ領域
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    handleFiles(e.dataTransfer.files);
+  };
+
+  // ドラッグオーバー時
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  // ドラッグリーブ時
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  return (
+    <div className="space-y-3">
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          handleFiles(e.target.files);
+          e.target.value = '';
+        }}
+      />
+
+      {/* クリックして選択 */}
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm"
+      >
+        クリックしてファイルを選択
+      </button>
+
+      {/* プレビュー枠 */}
+      <div className="flex h-30 items-center justify-center rounded-md border border-gray-300">
+        {previewUrl ? (
+          <img
+            src={previewUrl}
+            alt="プロフィール画像プレビュー"
+            className="h-full w-full rounded-md object-contain"
+          />
+        ) : (
+          <span>プロフィール画像</span>
+        )}
+      </div>
+
+      {/* ドラッグ＆ドロップ領域 */}
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        className={`flex flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed py-6 text-center transition-colors ${
+          isDragging
+            ? 'border-primary bg-primary/10'
+            : 'border-gray-300 bg-white'
+        }`}
+      >
+        <Upload className="h-5 w-5 text-gray-700" />
+        <p className="text-xs text-gray-600">
+          または
+          <br />
+          ファイルをここにドラッグアンドドロップ
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/student/components/EditForm/ImageUploader.tsx
+++ b/src/features/student/components/EditForm/ImageUploader.tsx
@@ -73,7 +73,7 @@ export function ImageUploader({ value, onChange }: Props) {
       </button>
 
       {/* プレビュー枠 */}
-      <div className="flex h-30 items-center justify-center rounded-md border border-gray-300">
+      <div className="border-input flex h-30 items-center justify-center rounded-md border shadow-xs">
         {previewUrl ? (
           <img
             src={previewUrl}
@@ -93,11 +93,11 @@ export function ImageUploader({ value, onChange }: Props) {
         className={`flex flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed py-6 text-center transition-colors ${
           isDragging
             ? 'border-primary bg-primary/10'
-            : 'border-gray-300 bg-white'
+            : 'border-input bg-white'
         }`}
       >
-        <Upload className="h-5 w-5 text-gray-700" />
-        <p className="text-xs text-gray-600">
+        <Upload className="h-5 w-5" />
+        <p className="text-xs">
           または
           <br />
           ファイルをここにドラッグアンドドロップ

--- a/src/features/student/components/SignupForm/SignupForm.tsx
+++ b/src/features/student/components/SignupForm/SignupForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useForm } from 'react-hook-form';
+import { useForm, type FieldErrors } from 'react-hook-form';
 import { SignupFormUI } from './SignupForm.ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
@@ -27,7 +27,7 @@ export function SignupForm() {
   const onSubmit = (data: SignupSchema) => {
     console.log('submit data:', data);
   };
-  const onError = (errors: any) => {
+  const onError = (errors: FieldErrors<SignupSchema>) => {
     console.log('submit errors:', errors);
   };
 

--- a/src/features/student/components/SignupForm/SignupForm.ui.tsx
+++ b/src/features/student/components/SignupForm/SignupForm.ui.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { UseFormReturn, FieldErrors } from 'react-hook-form';
-import { Controller } from 'react-hook-form';
-import { useFormState } from 'react-hook-form';
+import {
+  UseFormReturn,
+  FieldErrors,
+  Controller,
+  useFormState,
+} from 'react-hook-form';
 import { Input } from '@/components/atoms/Input';
 import { Button } from '@/components/atoms/Button';
 import { CalendarIcon } from 'lucide-react';
@@ -14,6 +17,7 @@ import {
 } from '@/components/atoms/Popover';
 import { RadioGroup, RadioGroupItem } from '@/components/atoms/RadioGroup';
 import { SignupSchema } from '../../validation/SignupSchema';
+import { format } from 'date-fns';
 
 type Props = {
   form: UseFormReturn<SignupSchema>;
@@ -118,9 +122,7 @@ export function SignupFormUI({ form, onSubmit, onError }: Props) {
                     mode="single"
                     selected={field.value ? new Date(field.value) : undefined}
                     onSelect={(date) =>
-                      field.onChange(
-                        date ? date.toISOString().split('T')[0] : '',
-                      )
+                      field.onChange(date ? format(date, 'yyyy-MM-dd') : '')
                     }
                     captionLayout="dropdown"
                   />

--- a/src/features/student/validation/EditSchema.ts
+++ b/src/features/student/validation/EditSchema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { signupSchema } from './SignupSchema';
+
+export const editSchema = signupSchema.extend({
+  profileImage: z.instanceof(File).optional(),
+});
+
+export type EditSchema = z.infer<typeof editSchema>;


### PR DESCRIPTION
## task
- JKA-1774

## 概要
- React ユーザー情報編集画面の実装（受講生側・画面のみ）

## 対応内容
- 受講生（生徒）側の「ユーザー情報編集」画面を実装。
- 受講生ヘッダーのドロップダウンメニュー「ユーザー情報編集」からの遷移を追加。

【新規】
src/app/(student)/profile/page.tsx：<EditForm /> をレンダリング
src/features/student/components/EditForm/EditForm.tsx：SignupForm.tsxを踏襲し、profileImageを追加
src/features/student/components/EditForm/EditForm.ui.tsx：SignupForm.ui.tsxを踏襲し、プロフィール画像アップロードの要素を追加
src/features/student/components/EditForm/ImageUploader.tsx：プロフィール画像アップロードの処理と画面要素を作成
src/features/student/validation/EditSchema.ts：signupSchema をベースに profileImage を任意項目であることを追加で設定

【更新】
src/components/organisms/Header/StudentHeader.ui.tsx：メニューリンクを /profile へ接続

## 動作確認手順
生徒側でログイン後、 http://localhost:3000/profile にアクセスし、画面表示を確認。

## スクショ
<img width="852" height="1032" alt="image" src="https://github.com/user-attachments/assets/edbda852-a883-4d49-85fa-23943334ddd3" />
  
## 確認してほしいこと
- 特にないです。