### PR TITLE
JKA-1776 React レッスン画面の実装（受講生側・画面のみ）

### DIFF
--- a/src/app/(student)/attendance/[attendanceId]/lessons/[lessonId]/page.tsx
+++ b/src/app/(student)/attendance/[attendanceId]/lessons/[lessonId]/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { LessonSidebar } from '@/features/attendance/components/LessonSidebar/LessonSidebar';
+import { Lesson } from '@/features/attendance/components/Lesson/Lesson';
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from '@/components/atoms/Sidebar';
+
+export default function LessonPage() {
+  const params = useParams();
+  const attendanceId = params.attendanceId as string;
+  const lessonId = params.lessonId as string;
+
+  return (
+    <SidebarProvider>
+      <LessonSidebar attendanceId={attendanceId} activeLessonId={lessonId} />
+      <SidebarInset>
+        <header className="flex h-12 items-center gap-2 border-b px-4">
+          <SidebarTrigger />
+          <span className="text-sm font-medium">レッスン</span>
+        </header>
+        <main className="flex-1 space-y-2 p-4">
+          <Lesson key={lessonId} lessonId={lessonId} />
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/src/features/attendance/components/Lesson/Lesson.tsx
+++ b/src/features/attendance/components/Lesson/Lesson.tsx
@@ -3,11 +3,7 @@
 import { useState } from 'react';
 
 import { LessonStatus } from '@/features/attendance/types/lessonStatus';
-import {
-  LessonUI,
-  LessonBreadcrumbItem,
-  LessonIndexItem,
-} from './Lesson.ui';
+import { LessonUI, LessonBreadcrumbItem, LessonIndexItem } from './Lesson.ui';
 
 // チャプタータイトル（値はダミー）
 const chapterTitle = 'チャプタータイトル';

--- a/src/features/attendance/components/Lesson/Lesson.tsx
+++ b/src/features/attendance/components/Lesson/Lesson.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+
+import { LessonStatus } from '@/features/attendance/types/lessonStatus';
+import {
+  LessonUI,
+  LessonBreadcrumbItem,
+  LessonIndexItem,
+} from './Lesson.ui';
+
+// チャプタータイトル（値はダミー）
+const chapterTitle = 'チャプタータイトル';
+
+// レッスン一覧（値はダミー）
+const lessons = [
+  { id: '1', title: 'Lesson 1' },
+  { id: '2', title: 'Lesson 2' },
+  { id: '3', title: 'Lesson 3' },
+  { id: '4', title: 'Lesson 4' },
+];
+
+// パンくずリスト（URLは未実装）
+const breadcrumbs: LessonBreadcrumbItem[] = [
+  { label: '講座分類', href: '#' },
+  { label: '講座一覧', href: '#' },
+  { label: 'チャプター&レッスン一覧', href: '#' },
+  { label: 'レッスン' },
+];
+
+// 動画URL（値はダミー）
+const videoUrl = '';
+
+// 目次（値はダミー）
+const index: LessonIndexItem[] = [
+  { label: '本レッスンの概要', time: '0:30~' },
+  { label: 'プログラミングとは', time: '1:00~' },
+  { label: 'PHPとはどんな言語', time: '4:00~' },
+  { label: 'PHPで計算してみよう', time: '7:00~' },
+  { label: 'まとめ', time: '9:00~' },
+];
+
+type LessonProps = {
+  lessonId: string;
+};
+
+export function Lesson({ lessonId }: LessonProps) {
+  const lessonTitle =
+    lessons.find((lesson) => lesson.id === lessonId)?.title ?? 'レッスン';
+
+  const [status, setStatus] = useState<LessonStatus>('before_attendance');
+
+  // 現状はstateボタン切り替え＋ログ出力
+  const handleStatusChange = (next: LessonStatus) => {
+    setStatus(next);
+    console.log('lesson status changed:', next);
+  };
+
+  return (
+    <LessonUI
+      breadcrumbs={breadcrumbs}
+      chapterTitle={chapterTitle}
+      lessonTitle={lessonTitle}
+      videoUrl={videoUrl}
+      index={index}
+      status={status}
+      onStatusChange={handleStatusChange}
+    />
+  );
+}

--- a/src/features/attendance/components/Lesson/Lesson.ui.tsx
+++ b/src/features/attendance/components/Lesson/Lesson.ui.tsx
@@ -41,7 +41,10 @@ export function LessonUI({
   return (
     <div className="space-y-4">
       {/* パンくず */}
-      <nav aria-label="パンくずリスト" className="text-muted-foreground text-xs">
+      <nav
+        aria-label="パンくずリスト"
+        className="text-muted-foreground text-xs"
+      >
         <ol className="flex flex-wrap items-center gap-1">
           {breadcrumbs.map((item, breadcrumbIndex) => {
             const isLast = breadcrumbIndex === breadcrumbs.length - 1;
@@ -80,10 +83,8 @@ export function LessonUI({
           className="aspect-video w-full rounded bg-black"
         />
       ) : (
-        <div className="flex aspect-video w-full items-center justify-center rounded bg-muted">
-          <span>
-            レッスン動画
-          </span>
+        <div className="bg-muted flex aspect-video w-full items-center justify-center rounded">
+          <span>レッスン動画</span>
         </div>
       )}
 

--- a/src/features/attendance/components/Lesson/Lesson.ui.tsx
+++ b/src/features/attendance/components/Lesson/Lesson.ui.tsx
@@ -1,0 +1,123 @@
+import Link from 'next/link';
+
+import { Button } from '@/components/atoms/Button';
+import { LessonStatus } from '@/features/attendance/types/lessonStatus';
+
+export type LessonBreadcrumbItem = {
+  label: string;
+  href?: string;
+};
+
+export type LessonIndexItem = {
+  label: string;
+  time: string;
+};
+
+const STATUS_BUTTONS: { status: LessonStatus; label: string }[] = [
+  { status: 'before_attendance', label: 'Lesson未実施' },
+  { status: 'in_attendance', label: 'Lesson開始' },
+  { status: 'completed_attendance', label: 'Lesson完了' },
+];
+
+type LessonUIProps = {
+  breadcrumbs: LessonBreadcrumbItem[];
+  chapterTitle: string;
+  lessonTitle: string;
+  videoUrl?: string;
+  index: LessonIndexItem[];
+  status: LessonStatus;
+  onStatusChange: (status: LessonStatus) => void;
+};
+
+export function LessonUI({
+  breadcrumbs,
+  chapterTitle,
+  lessonTitle,
+  videoUrl,
+  index,
+  status,
+  onStatusChange,
+}: LessonUIProps) {
+  return (
+    <div className="space-y-4">
+      {/* パンくず */}
+      <nav aria-label="パンくずリスト" className="text-muted-foreground text-xs">
+        <ol className="flex flex-wrap items-center gap-1">
+          {breadcrumbs.map((item, breadcrumbIndex) => {
+            const isLast = breadcrumbIndex === breadcrumbs.length - 1;
+
+            return (
+              <li key={item.label} className="flex items-center gap-1">
+                {item.href && !isLast ? (
+                  <Link href={item.href} className="hover:text-foreground">
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span className="text-foreground">{item.label}</span>
+                )}
+
+                {!isLast && <span>&gt;</span>}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      {/* チャプタータイトル */}
+      <div className="space-y-4">
+        <h1 className="text-lg font-semibold">{chapterTitle}</h1>
+        <hr className="border-border" />
+      </div>
+
+      {/* レッスンタイトル */}
+      <h2 className="text-xl font-bold">{lessonTitle}</h2>
+
+      {/* 動画プレイヤー */}
+      {videoUrl ? (
+        <video
+          controls
+          src={videoUrl}
+          className="aspect-video w-full rounded bg-black"
+        />
+      ) : (
+        <div className="flex aspect-video w-full items-center justify-center rounded bg-muted">
+          <span>
+            レッスン動画
+          </span>
+        </div>
+      )}
+
+      {/* ステータス操作ボタン */}
+      <div className="flex flex-wrap gap-3">
+        {STATUS_BUTTONS.map((button) => {
+          const isActive = button.status === status;
+
+          return (
+            <Button
+              key={button.status}
+              type="button"
+              variant={isActive ? 'default' : 'outline'}
+              aria-pressed={isActive}
+              onClick={() => onStatusChange(button.status)}
+            >
+              {button.label}
+            </Button>
+          );
+        })}
+      </div>
+
+      {/* インデックス（目次） */}
+      <div className="space-y-1 text-sm">
+        <p className="font-semibold">Index</p>
+        <ul>
+          {index.map((item) => (
+            <li key={item.label} className="flex gap-4">
+              <span>・{item.label}</span>
+              <span>{item.time}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/features/attendance/components/LessonSidebar/LessonSidebar.tsx
+++ b/src/features/attendance/components/LessonSidebar/LessonSidebar.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { LessonListItem } from '@/features/attendance/types/lessonListItem';
+import { LessonSidebarUI } from './LessonSidebar.ui';
+
+/** チャプター進捗率（値はダミー） */
+const chapterProgressPercent = 33;
+
+/** レッスン一覧（値はダミー） */
+const lessons: LessonListItem[] = [
+  { id: '1', title: 'Lesson 1', status: 'in_attendance' },
+  { id: '2', title: 'Lesson 2', status: 'before_attendance' },
+  { id: '3', title: 'Lesson 3', status: 'before_attendance' },
+  { id: '4', title: 'Lesson 4', status: 'completed_attendance' },
+];
+
+type LessonSidebarProps = {
+  attendanceId: string;
+  activeLessonId: string;
+};
+
+export function LessonSidebar({
+  attendanceId,
+  activeLessonId,
+}: LessonSidebarProps) {
+  return (
+    <LessonSidebarUI
+      attendanceId={attendanceId}
+      progressPercent={chapterProgressPercent}
+      lessons={lessons}
+      activeLessonId={activeLessonId}
+    />
+  );
+}

--- a/src/features/attendance/components/LessonSidebar/LessonSidebar.ui.tsx
+++ b/src/features/attendance/components/LessonSidebar/LessonSidebar.ui.tsx
@@ -35,9 +35,9 @@ export function LessonSidebarUI({
           <p className="text-xs font-medium">チャプター進捗</p>
           <Badge variant="secondary">{progressPercent}%</Badge>
         </div>
-        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
           <div
-            className="h-full rounded-full bg-primary transition-all"
+            className="bg-primary h-full rounded-full transition-all"
             style={{ width: `${progressPercent}%` }}
           />
         </div>
@@ -56,7 +56,7 @@ export function LessonSidebarUI({
                   <li key={lesson.id} className="border-b">
                     <Link
                       href={`/attendance/${attendanceId}/lessons/${lesson.id}`}
-                      className="flex items-center justify-between px-3 py-3 hover:bg-accent"
+                      className="hover:bg-accent flex items-center justify-between px-3 py-3"
                     >
                       <span
                         className={cn(
@@ -64,10 +64,8 @@ export function LessonSidebarUI({
                           isCompleted && 'text-orange-500',
                           !isCompleted &&
                             isActive &&
-                            'font-medium text-primary',
-                          !isCompleted &&
-                            !isActive &&
-                            'text-muted-foreground',
+                            'text-primary font-medium',
+                          !isCompleted && !isActive && 'text-muted-foreground',
                         )}
                       >
                         {lesson.title}

--- a/src/features/attendance/components/LessonSidebar/LessonSidebar.ui.tsx
+++ b/src/features/attendance/components/LessonSidebar/LessonSidebar.ui.tsx
@@ -1,0 +1,98 @@
+import Link from 'next/link';
+import { CheckCircle2, Circle } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/atoms/Badge';
+import type { LessonListItem } from '@/features/attendance/types/lessonListItem';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+} from '@/components/atoms/Sidebar';
+
+export type LessonSidebarItem = LessonListItem;
+
+export type LessonSidebarUIProps = {
+  attendanceId: string;
+  progressPercent: number;
+  lessons: LessonSidebarItem[];
+  activeLessonId: string;
+};
+
+export function LessonSidebarUI({
+  attendanceId,
+  progressPercent,
+  lessons,
+  activeLessonId,
+}: LessonSidebarUIProps) {
+  return (
+    <Sidebar collapsible="offcanvas">
+      {/* チャプター進捗 */}
+      <SidebarHeader className="gap-2 p-4">
+        <div className="flex items-center gap-2">
+          <p className="text-xs font-medium">チャプター進捗</p>
+          <Badge variant="secondary">{progressPercent}%</Badge>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      </SidebarHeader>
+
+      <SidebarContent>
+        {/* レッスン一覧 */}
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <ul>
+              {lessons.map((lesson) => {
+                const isActive = lesson.id === activeLessonId;
+                const isCompleted = lesson.status === 'completed_attendance';
+
+                return (
+                  <li key={lesson.id} className="border-b">
+                    <Link
+                      href={`/attendance/${attendanceId}/lessons/${lesson.id}`}
+                      className="flex items-center justify-between px-3 py-3 hover:bg-accent"
+                    >
+                      <span
+                        className={cn(
+                          'text-sm',
+                          isCompleted && 'text-orange-500',
+                          !isCompleted &&
+                            isActive &&
+                            'font-medium text-primary',
+                          !isCompleted &&
+                            !isActive &&
+                            'text-muted-foreground',
+                        )}
+                      >
+                        {lesson.title}
+                      </span>
+
+                      {isCompleted ? (
+                        <CheckCircle2 className="h-4 w-4 text-orange-500" />
+                      ) : (
+                        <Circle
+                          className={cn(
+                            'h-4 w-4',
+                            isActive
+                              ? 'fill-primary text-primary'
+                              : 'fill-muted-foreground/40 text-muted-foreground/40',
+                          )}
+                        />
+                      )}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  );
+}

--- a/src/features/attendance/types/lessonListItem.ts
+++ b/src/features/attendance/types/lessonListItem.ts
@@ -1,0 +1,7 @@
+import type { LessonStatus } from '@/features/attendance/types/lessonStatus';
+
+export type LessonListItem = {
+  id: string;
+  title: string;
+  status: LessonStatus;
+};

--- a/src/features/attendance/types/lessonStatus.ts
+++ b/src/features/attendance/types/lessonStatus.ts
@@ -1,0 +1,5 @@
+/** レッスンの受講ステータス */
+export type LessonStatus =
+  | 'before_attendance' // 未実施
+  | 'in_attendance' // 視聴中／選択中
+  | 'completed_attendance'; // 完了


### PR DESCRIPTION
## task
- JKA-1774

## 概要
- React レッスン画面の実装（受講生側・画面のみ）

## 対応内容
実装した受講生側「ユーザー情報編集」画面（/profile）に、生徒情報のAPI連携を追加する。

■やること
1.  サイドバー
- チャプター進捗：プログレスバー＋パーセンテージ
- レッスン一覧：レッスンのリンクと各レッスンのアイコン表示
- 折りたたみトグル　※既存を踏襲

2. メインエリア
- パンくず
- 見出し
- 動画プレイヤー
- ステータス操作ボタン
- インデックス（目次）

【新規】
src/app/(student)/attendance/[attendanceId]/lessons/[lessonId]/page.tsx：レッスン画面のベース
src/features/attendance/components/Lesson/Lesson.tsx：メイン画面で使うものの定義
src/features/attendance/components/Lesson/Lesson.ui.tsx：メイン画面の見た目の定義
src/features/attendance/components/LessonSidebar/LessonSidebar.tsx：サイドバーで使うものの定義
src/features/attendance/components/LessonSidebar/LessonSidebar.ui.tsx：サイドバーの見た目の定義
src/features/attendance/types/lessonListItem.ts：レッスンの項目の型定義
src/features/attendance/types/lessonStatus.ts：レッスンのステータスをunion 型で定義

## 動作確認手順
生徒側でログイン後、 http://localhost:3000/attendance/1/lessons/1に遷移
画面全体とサイドバーの表示を確認
リンクやボタンも設定されていることを押下して確認

## スクショ
メイン画面
<img width="760" height="1032" alt="image" src="https://github.com/user-attachments/assets/b44d7c10-ef52-4dc2-b208-3ebd5a680ee0" />

サイドバー
<img width="760" height="1032" alt="image" src="https://github.com/user-attachments/assets/c6d46880-f12a-4b29-a051-8432b9e40812" />

  